### PR TITLE
Fix balance due logic and conditionally apply strikethrough to origin…

### DIFF
--- a/components/pacientes/modales/pagar-cita.vue
+++ b/components/pacientes/modales/pagar-cita.vue
@@ -180,11 +180,17 @@ const isCreditApproved = computed(() => {
 });
 
 const balanceDue = computed(() => {
-  if (isValoration.value) {
-    return Number(props.appointment.package.discount ?? 0);
+  if (!isValoration.value) {
+    return (
+      Number(props.appointment.price_procedure) - approvedCreditAmount.value
+    );
   }
 
-  return Number(props.appointment.price_procedure) - approvedCreditAmount.value;
+  if (Number(props.appointment.package.discount) === 0) {
+    return Number(props.appointment.package.product.value2);
+  }
+
+  return Number(props.appointment.package.discount ?? 0);
 });
 
 const canProceedWithPayment = computed(
@@ -202,6 +208,8 @@ const displayDiscount = computed(() => {
 
   const value2 = Number(props.appointment.package.product.value2 ?? 0);
   const vitalink = Number(props.appointment.package.discount ?? 0);
+
+  if (vitalink === 0) return formatCurrency(0, { decimalPlaces: 0 });
 
   const discount = value2 - vitalink;
 

--- a/components/website/tarjeta-medico.vue
+++ b/components/website/tarjeta-medico.vue
@@ -116,7 +116,13 @@
         <footer class="supplier-card__footer">
           <div class="supplier-card__pricing" aria-label="Precio de valoración">
             <div v-if="hasLoadedPricing" class="supplier-card__pricing-amounts">
-              <p class="supplier-card__pricing-original">
+              <p
+                class="supplier-card__pricing-original"
+                :class="{
+                  'supplier-card__pricing-original--line-through':
+                    hasDiscountedPrice,
+                }"
+              >
                 <span class="sr-only">Precio original: </span>
                 {{ formattedOriginalPrice }}
               </p>
@@ -191,6 +197,13 @@ const locationLabel = computed<string>(() =>
 );
 
 const hasLoadedPricing = computed<boolean>(() => originalPrice.value !== null);
+
+const hasDiscountedPrice = computed<boolean>(
+  () =>
+    discountedPrice.value !== null &&
+    parseFloat(String(discountedPrice.value)) <
+      parseFloat(String(originalPrice.value)),
+);
 
 const formattedOriginalPrice = computed<string>(() => {
   if (!originalPrice.value) return "";
@@ -647,8 +660,12 @@ onMounted(fetchSupplierPackages);
     font-weight: 700;
     font-size: 16px;
     line-height: 1.2;
-    color: #6d758f;
-    text-decoration: line-through;
+    color: $color-foreground;
+
+    &--line-through {
+      text-decoration: line-through;
+      color: #6d758f;
+    }
 
     @include respond-to(md) {
       font-size: 18.9px;
@@ -661,7 +678,7 @@ onMounted(fetchSupplierPackages);
     font-weight: 700;
     font-size: 16px;
     line-height: 1.2;
-    color: #353e5c;
+    color: $color-foreground;
 
     @include respond-to(md) {
       font-size: 18.9px;


### PR DESCRIPTION
…al price

- Correct balanceDue computation for valorations: show package value2 when discount is 0
- Guard displayDiscount against zero-discount edge case
- Apply line-through style to original price only when a lower discounted price exists
- Use $color-foreground token instead of hardcoded hex values for price text