### PR TITLE
Add document identity fields to registration and overhaul password reset flow

### DIFF
--- a/assets/scss/_mixin.scss
+++ b/assets/scss/_mixin.scss
@@ -268,6 +268,42 @@
   }
 }
 
+@mixin custom-checkbox {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 18px;
+  height: 18px;
+  min-width: 18px;
+  border-radius: 4px;
+  border: 2px solid #c1c7d0;
+  margin: 0;
+  cursor: pointer;
+  position: relative;
+  flex-shrink: 0;
+  background-color: white;
+  transition:
+    border-color 0.15s,
+    background-color 0.15s;
+
+  &:checked {
+    border-color: $color-primary;
+    background-color: $color-primary;
+
+    &::after {
+      content: "";
+      position: absolute;
+      top: 1px;
+      left: 5px;
+      width: 5px;
+      height: 9px;
+      border: 2px solid white;
+      border-top: none;
+      border-left: none;
+      transform: rotate(45deg);
+    }
+  }
+}
+
 @mixin input-base {
   @include input-reset;
   border-radius: $border-radius-md;

--- a/components/pacientes/registro/formulario-registro-correo.vue
+++ b/components/pacientes/registro/formulario-registro-correo.vue
@@ -1,230 +1,271 @@
 <template>
-  <div
-    class="registration-form"
-    role="region"
-    aria-labelledby="registration-form-title"
-  >
-    <h2 id="registration-form-title" class="sr-only">
-      Formulario de registro con correo electrónico
-    </h2>
-
+  <div class="registration-form">
     <form
       @submit.prevent="handleSubmit"
       class="registration-form__main"
       novalidate
-      aria-describedby="form-instructions"
     >
-      <p id="form-instructions" class="sr-only">
-        Complete todos los campos requeridos. Los campos con asterisco son
-        obligatorios.
-      </p>
+      <fieldset class="registration-form__fieldset">
+        <legend class="registration-form__heading">
+          Completa tus datos de registro
+        </legend>
 
-      <div class="registration-field-group">
-        <label for="nombre" class="registration-label">
-          Tu nombre
-          <span aria-hidden="true">*</span>
-        </label>
-        <input
-          v-model="name"
-          type="text"
-          id="nombre"
-          placeholder="Escribe tu nombre"
-          required
-          aria-required="true"
-          :aria-invalid="errors.name ? 'true' : 'false'"
-          :aria-describedby="errors.name ? 'nombre-error' : undefined"
-          class="registration-input"
-          @blur="validateName"
-        />
-        <span
-          v-if="errors.name"
-          id="nombre-error"
-          class="registration-error"
-          role="alert"
-        >
-          {{ errors.name }}
-        </span>
-      </div>
-
-      <div class="registration-field-group">
-        <label for="email" class="registration-label">
-          Correo electrónico o número de teléfono
-          <span aria-hidden="true">*</span>
-        </label>
-        <input
-          v-model="email"
-          type="email"
-          id="email"
-          placeholder="Tu correo electrónico o número de teléfono"
-          required
-          aria-required="true"
-          :aria-invalid="errors.email ? 'true' : 'false'"
-          :aria-describedby="errors.email ? 'email-error' : undefined"
-          class="registration-input"
-          @blur="validateEmail"
-        />
-        <span
-          v-if="errors.email"
-          id="email-error"
-          class="registration-error"
-          role="alert"
-        >
-          {{ errors.email }}
-        </span>
-      </div>
-
-      <div class="registration-field-group">
-        <label for="password" class="registration-label">
-          Contraseña
-          <span aria-hidden="true">*</span>
-        </label>
-        <div class="password-field-wrapper">
-          <input
-            v-model="password"
-            :type="showPassword ? 'text' : 'password'"
-            id="password"
-            placeholder="Escribe tu contraseña"
-            required
-            aria-required="true"
-            :aria-invalid="errors.password ? 'true' : 'false'"
-            :aria-describedby="
-              errors.password ? 'password-error password-hint' : 'password-hint'
-            "
-            class="registration-input"
-            @blur="validatePassword"
-          />
-          <button
-            type="button"
-            class="password-toggle"
-            @click="showPassword = !showPassword"
-            :aria-label="
-              showPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'
-            "
-            :aria-pressed="showPassword"
-          >
-            <span aria-hidden="true">{{ showPassword ? "👁️" : "👁️‍🗨️" }}</span>
-          </button>
-        </div>
-        <small id="password-hint" class="registration-hint">
-          Debe tener al menos 8 caracteres
-        </small>
-        <span
-          v-if="errors.password"
-          id="password-error"
-          class="registration-error"
-          role="alert"
-        >
-          {{ errors.password }}
-        </span>
-      </div>
-
-      <div class="registration-field-group">
-        <label class="registration-label">
-          Asociación Solidarista
-          <span aria-hidden="true">*</span>
-        </label>
-        <UiDropdownBase
-          v-model="solidaristaAssociation"
-          :items="financeEntityItems"
-          placeholder="Selecciona tu asociación"
-          searchable
-          clearable
-        />
-        <span
-          v-if="errors.solidarista"
-          id="solidarista-error"
-          class="registration-error"
-          role="alert"
-        >
-          {{ errors.solidarista }}
-        </span>
-      </div>
-
-      <fieldset class="registration-options-group" aria-required="true">
-        <legend class="sr-only">Aceptación de términos y políticas</legend>
-
-        <div class="registration-terms-group">
-          <div class="registration-option">
-            <input
-              type="checkbox"
-              id="terms"
-              v-model="acceptedTerms"
-              class="registration-checkbox"
-              aria-required="true"
-              :aria-invalid="errors.terms ? 'true' : 'false'"
-              :aria-describedby="errors.terms ? 'terms-error' : undefined"
-              @change="validateTerms"
+        <div class="registration-form__row">
+          <div class="registration-field-group">
+            <label for="document-type" class="registration-label">
+              Tipo de documento de identidad
+              <span aria-hidden="true">*</span>
+            </label>
+            <UiDropdownBase
+              id="document-type"
+              v-model="documentType"
+              :items="documentTypeItems"
+              :loading="isLoadingDocumentTypes"
+              placeholder="Selecciona tipo de documento"
+              :aria-invalid="errors.documentType ? 'true' : 'false'"
+              :aria-describedby="
+                errors.documentType ? 'document-type-error' : undefined
+              "
+              @blur="validateDocumentType"
             />
-            <label for="terms" class="registration-option-label">
-              <span>
+            <span
+              v-if="errors.documentType"
+              id="document-type-error"
+              class="registration-error"
+              role="alert"
+            >
+              {{ errors.documentType }}
+            </span>
+          </div>
+
+          <div class="registration-field-group">
+            <label for="document-number" class="registration-label">
+              Número de documento
+              <span aria-hidden="true">*</span>
+            </label>
+            <input
+              id="document-number"
+              :value="documentNumber"
+              type="text"
+              class="registration-input"
+              :class="{ 'registration-input--invalid': errors.documentNumber }"
+              :placeholder="getCedulaPlaceholder(documentType)"
+              :aria-invalid="errors.documentNumber ? 'true' : 'false'"
+              :aria-describedby="
+                errors.documentNumber ? 'document-number-error' : undefined
+              "
+              @input="handleDocumentNumberInput"
+              @blur="validateDocumentNumber"
+            />
+            <span
+              v-if="errors.documentNumber"
+              id="document-number-error"
+              class="registration-error"
+              role="alert"
+            >
+              {{ errors.documentNumber }}
+            </span>
+          </div>
+        </div>
+
+        <div class="registration-field-group">
+          <label for="nombre" class="registration-label">
+            Tu nombre
+            <span aria-hidden="true">*</span>
+          </label>
+          <input
+            v-model="name"
+            type="text"
+            id="nombre"
+            placeholder="Escribe tu nombre"
+            class="registration-input"
+            :class="{ 'registration-input--invalid': errors.name }"
+            :aria-invalid="errors.name ? 'true' : 'false'"
+            :aria-describedby="errors.name ? 'nombre-error' : undefined"
+            @blur="validateName"
+          />
+          <span
+            v-if="errors.name"
+            id="nombre-error"
+            class="registration-error"
+            role="alert"
+          >
+            {{ errors.name }}
+          </span>
+        </div>
+
+        <div class="registration-field-group">
+          <label for="email" class="registration-label">
+            Correo electrónico
+            <span aria-hidden="true">*</span>
+          </label>
+          <input
+            v-model="email"
+            type="email"
+            id="email"
+            placeholder="Tu correo electrónico"
+            class="registration-input"
+            :class="{ 'registration-input--invalid': errors.email }"
+            :aria-invalid="errors.email ? 'true' : 'false'"
+            :aria-describedby="errors.email ? 'email-error' : undefined"
+            @blur="validateEmail"
+          />
+          <span
+            v-if="errors.email"
+            id="email-error"
+            class="registration-error"
+            role="alert"
+          >
+            {{ errors.email }}
+          </span>
+        </div>
+
+        <div class="registration-field-group">
+          <label for="password" class="registration-label">
+            Contraseña
+            <span aria-hidden="true">*</span>
+          </label>
+          <div class="password-field-wrapper">
+            <input
+              v-model="password"
+              :type="showPassword ? 'text' : 'password'"
+              id="password"
+              placeholder="Escribe tu contraseña"
+              class="registration-input"
+              :class="{ 'registration-input--invalid': errors.password }"
+              :aria-invalid="errors.password ? 'true' : 'false'"
+              :aria-describedby="
+                errors.password
+                  ? 'password-error password-hint'
+                  : 'password-hint'
+              "
+              @blur="validatePassword"
+            />
+            <button
+              type="button"
+              class="password-toggle"
+              @click="showPassword = !showPassword"
+              :aria-label="
+                showPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'
+              "
+              :aria-pressed="showPassword"
+            >
+              <span aria-hidden="true">{{ showPassword ? "👁️" : "👁️‍🗨️" }}</span>
+            </button>
+          </div>
+          <small id="password-hint" class="registration-hint">
+            Debe tener al menos 8 caracteres
+          </small>
+          <span
+            v-if="errors.password"
+            id="password-error"
+            class="registration-error"
+            role="alert"
+          >
+            {{ errors.password }}
+          </span>
+        </div>
+
+        <div class="registration-field-group">
+          <label for="solidarista" class="registration-label">
+            Asociación Solidarista
+            <span aria-hidden="true">*</span>
+          </label>
+          <UiDropdownBase
+            id="solidarista"
+            v-model="solidaristaAssociation"
+            :items="financeEntityItems"
+            placeholder="Selecciona tu asociación"
+            searchable
+            clearable
+          />
+          <span
+            v-if="errors.solidarista"
+            id="solidarista-error"
+            class="registration-error"
+            role="alert"
+          >
+            {{ errors.solidarista }}
+          </span>
+        </div>
+
+        <fieldset class="registration-options-group" aria-required="true">
+          <legend class="sr-only">Aceptación de términos y políticas</legend>
+          <div class="registration-terms-group">
+            <div class="registration-option">
+              <input
+                type="checkbox"
+                id="terms"
+                v-model="acceptedTerms"
+                class="registration-checkbox"
+                @change="validateTerms"
+              />
+              <label for="terms" class="registration-option-label">
                 He leído y acepto los
                 <a
                   href="/documentos/terminos-condiciones.pdf"
                   target="_blank"
                   rel="noopener noreferrer"
                   download
-                  aria-label="Términos y Condiciones (se abre en una nueva pestaña)"
                 >
                   Términos y Condiciones
                 </a>
-              </span>
-            </label>
-          </div>
-          <span
-            v-if="errors.terms"
-            id="terms-error"
-            class="registration-error"
-            role="alert"
-          >
-            {{ errors.terms }}
-          </span>
+              </label>
+            </div>
+            <span
+              v-if="errors.terms"
+              id="terms-error"
+              class="registration-error"
+              role="alert"
+            >
+              {{ errors.terms }}
+            </span>
 
-          <div class="registration-option">
-            <input
-              type="checkbox"
-              id="privacy"
-              v-model="acceptedPrivacy"
-              class="registration-checkbox"
-              aria-required="true"
-              :aria-invalid="errors.privacy ? 'true' : 'false'"
-              :aria-describedby="errors.privacy ? 'privacy-error' : undefined"
-              @change="validatePrivacy"
-            />
-            <label for="privacy" class="registration-option-label">
-              <span>
+            <div class="registration-option">
+              <input
+                type="checkbox"
+                id="privacy"
+                v-model="acceptedPrivacy"
+                class="registration-checkbox"
+                @change="validatePrivacy"
+              />
+              <label for="privacy" class="registration-option-label">
                 He leído y acepto la
                 <a
                   href="/documentos/politica-privacidad.pdf"
                   target="_blank"
                   rel="noopener noreferrer"
                   download
-                  aria-label="Política de Privacidad (se abre en una nueva pestaña)"
                 >
                   Política de Privacidad
                 </a>
-              </span>
-            </label>
+              </label>
+            </div>
+            <span
+              v-if="errors.privacy"
+              id="privacy-error"
+              class="registration-error"
+              role="alert"
+            >
+              {{ errors.privacy }}
+            </span>
           </div>
-          <span
-            v-if="errors.privacy"
-            id="privacy-error"
-            class="registration-error"
-            role="alert"
-          >
-            {{ errors.privacy }}
-          </span>
-        </div>
-      </fieldset>
+        </fieldset>
 
-      <button
-        type="submit"
-        class="registration-submit-button"
-        :disabled="isSubmitting || !acceptedTerms || !acceptedPrivacy"
-        :aria-busy="isSubmitting"
-      >
-        <span v-if="!isSubmitting">Registrarme</span>
-        <span v-else>Procesando...</span>
-      </button>
+        <button
+          type="submit"
+          class="registration-submit-button"
+          :disabled="isSubmitting || !acceptedTerms || !acceptedPrivacy"
+          :aria-busy="isSubmitting"
+        >
+          <span
+            v-if="isSubmitting"
+            class="registration-submit-button__spinner"
+            aria-hidden="true"
+          />
+          {{ isSubmitting ? "Procesando..." : "Registrarme" }}
+        </button>
+      </fieldset>
     </form>
 
     <div
@@ -235,7 +276,6 @@
       <p class="registration-social-login__label">
         <span>O hacerlo con:</span>
       </p>
-
       <div class="registration-social-buttons">
         <button
           type="button"
@@ -268,22 +308,29 @@
         </NuxtLink>
       </p>
     </div>
-
-    <div class="sr-only" role="status" aria-live="polite" aria-atomic="true">
-      {{ statusMessage }}
-    </div>
   </div>
 </template>
 
 <script lang="ts" setup>
 import { useRuntimeConfig } from "#app";
-import { useFinanceEntity } from "@/composables/api";
+import { useFinanceEntity, useUdc } from "@/composables/api";
+import { useFormat } from "@/composables/useFormat";
 import { useLogger } from "@/composables/useLogger";
-import { useRouter } from "vue-router";
-
+import { useToast } from "@/composables/useToast";
 const { getAllFinanceEntities } = useFinanceEntity();
+const { getAllUdcs } = useUdc();
+const {
+  formatCedula,
+  validateCedula,
+  getCedulaPlaceholder,
+  getCedulaErrorMessage,
+  convertCedulaForBackend,
+} = useFormat();
 const logger = useLogger("formulario-registro-correo");
+const toast = useToast();
 
+const documentType = ref("");
+const documentNumber = ref("");
 const name = ref("");
 const email = ref("");
 const password = ref("");
@@ -292,19 +339,24 @@ const showPassword = ref(false);
 const acceptedTerms = ref(false);
 const acceptedPrivacy = ref(false);
 const isSubmitting = ref(false);
-const statusMessage = ref("");
 const financeEntities = ref<IUdc[]>([]);
+const documentTypeOptions = ref<IUdc[]>([]);
+const isLoadingDocumentTypes = ref(false);
 
-const financeEntityItems = computed(() => {
-  const items = financeEntities.value.map((e) => ({
-    value: e.id,
-    label: e.name,
-  }));
-  logger.debug("financeEntityItems computed", { items });
-  return items;
-});
+const documentTypeItems = computed(() =>
+  documentTypeOptions.value.map((opt) => ({
+    value: opt.code,
+    label: opt.name,
+  })),
+);
+
+const financeEntityItems = computed(() =>
+  financeEntities.value.map((e) => ({ value: e.id, label: e.name })),
+);
 
 const errors = reactive({
+  documentType: "",
+  documentNumber: "",
   name: "",
   email: "",
   password: "",
@@ -316,18 +368,27 @@ const errors = reactive({
 const config = useRuntimeConfig();
 const router = useRouter();
 
-async function executeGetAllFinanceEntities() {
-  try {
-    const entitiesResponse = await getAllFinanceEntities();
-    financeEntities.value = entitiesResponse.data ?? [];
-    logger.debug("Entidades financieras obtenidas", {
-      count: financeEntities.value.length,
-      entities: financeEntities.value,
-    });
-  } catch (error) {
-    logger.error("Error al obtener entidades financieras", { error });
+const validateDocumentType = () => {
+  if (!documentType.value) {
+    errors.documentType = "Debes seleccionar un tipo de documento";
+    return false;
   }
-}
+  errors.documentType = "";
+  return true;
+};
+
+const validateDocumentNumber = () => {
+  if (!documentNumber.value.trim()) {
+    errors.documentNumber = "El número de documento es requerido";
+    return false;
+  }
+  if (!validateCedula(documentNumber.value, documentType.value)) {
+    errors.documentNumber = getCedulaErrorMessage(documentType.value);
+    return false;
+  }
+  errors.documentNumber = "";
+  return true;
+};
 
 const validateName = () => {
   if (!name.value.trim()) {
@@ -378,11 +439,6 @@ const validateSolidarista = () => {
   return true;
 };
 
-watch(solidaristaAssociation, (val) => {
-  logger.debug("solidaristaAssociation changed", { val, type: typeof val });
-  if (val) errors.solidarista = "";
-});
-
 const validateTerms = () => {
   if (!acceptedTerms.value) {
     errors.terms = "Debes aceptar los Términos y Condiciones";
@@ -402,38 +458,48 @@ const validatePrivacy = () => {
 };
 
 const validateForm = () => {
-  const isNameValid = validateName();
-  const isEmailValid = validateEmail();
-  const isPasswordValid = validatePassword();
-  const isSolidaristaValid = validateSolidarista();
-  const areTermsValid = validateTerms();
-  const isPrivacyValid = validatePrivacy();
-
-  return (
-    isNameValid &&
-    isEmailValid &&
-    isPasswordValid &&
-    isSolidaristaValid &&
-    areTermsValid &&
-    isPrivacyValid
-  );
+  return [
+    validateDocumentType(),
+    validateDocumentNumber(),
+    validateName(),
+    validateEmail(),
+    validatePassword(),
+    validateSolidarista(),
+    validateTerms(),
+    validatePrivacy(),
+  ].every(Boolean);
 };
 
-const handleSubmit = async () => {
-  logger.debug("handleSubmit called", {
-    solidaristaAssociation: solidaristaAssociation.value,
-    solidaristaType: typeof solidaristaAssociation.value,
-  });
+const handleDocumentNumberInput = (event: Event) => {
+  const target = event.target as HTMLInputElement;
+  const formatted = formatCedula(target.value, documentType.value);
+  documentNumber.value = formatted;
+  target.value = formatted;
+  if (errors.documentNumber) validateDocumentNumber();
+};
 
-  if (!validateForm()) {
-    statusMessage.value = "Por favor corrige los errores en el formulario";
-    return;
-  }
+watch(documentType, () => {
+  documentNumber.value = "";
+  errors.documentNumber = "";
+});
+
+watch(solidaristaAssociation, (val) => {
+  if (val) errors.solidarista = "";
+});
+
+const handleSubmit = async () => {
+  if (!validateForm()) return;
 
   isSubmitting.value = true;
-  statusMessage.value = "Procesando tu registro...";
+
+  const backendDocumentNumber = convertCedulaForBackend(
+    documentNumber.value,
+    documentType.value,
+  );
 
   const payload = {
+    card_id: backendDocumentNumber,
+    id_type: documentType.value,
     name: name.value,
     email: email.value,
     password: password.value,
@@ -453,35 +519,59 @@ const handleSubmit = async () => {
       },
     );
 
+    if (error.value) {
+      logger.error("Register error", {
+        status: error.value.statusCode,
+        message: error.value.message,
+        data: error.value.data,
+      });
+      toast.error("Error al registrar. Por favor intenta nuevamente.");
+      return;
+    }
+
     if (data.value) {
       await useFetch(config.public.API_BASE_URL + "/forgot_password", {
         method: "POST",
         body: { email: email.value },
       });
 
-      statusMessage.value = "Registro exitoso. Redirigiendo...";
-      router.push("/auth/registro-exitoso");
-    } else {
-      statusMessage.value = "Error al registrar. Por favor intenta nuevamente.";
+      toast.success("Registro exitoso. Revisa tu correo electrónico para verificar tu cuenta.");
     }
   } catch (error) {
-    statusMessage.value =
-      "Error al procesar el registro. Por favor intenta nuevamente.";
+    logger.error("Register exception", { error });
+    toast.error("Error al procesar el registro. Por favor intenta nuevamente.");
   } finally {
     isSubmitting.value = false;
   }
 };
 
-const loginWithGoogle = () => {
-  statusMessage.value = "Iniciando registro con Google...";
-};
+const loginWithGoogle = () => {};
+const loginWithApple = () => {};
 
-const loginWithApple = () => {
-  statusMessage.value = "Iniciando registro con Apple...";
-};
+async function loadDocumentTypes() {
+  isLoadingDocumentTypes.value = true;
+  try {
+    const { data } = await getAllUdcs({ type: "ID_TYPE" as any }, false);
+    if (data) documentTypeOptions.value = data;
+  } catch {
+    documentTypeOptions.value = [];
+  } finally {
+    isLoadingDocumentTypes.value = false;
+  }
+}
+
+async function loadFinanceEntities() {
+  try {
+    const entitiesResponse = await getAllFinanceEntities();
+    financeEntities.value = entitiesResponse.data ?? [];
+  } catch (error) {
+    logger.error("Error al obtener entidades financieras", { error });
+  }
+}
 
 onMounted(() => {
-  executeGetAllFinanceEntities();
+  loadDocumentTypes();
+  loadFinanceEntities();
 });
 </script>
 
@@ -494,10 +584,36 @@ onMounted(() => {
 .registration-form__main {
   display: flex;
   flex-direction: column;
+}
+
+.registration-form__fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
   gap: $spacing-lg;
 }
 
+.registration-form__heading {
+  @include label-base;
+  font-size: 0.9375rem;
+  color: #353e5c;
+  font-weight: 600;
+  padding: 0;
+}
+
+.registration-form__row {
+  display: flex;
+  gap: 1rem;
+
+  @media (max-width: 48rem) {
+    flex-direction: column;
+  }
+}
+
 .registration-field-group {
+  flex: 1;
   display: flex;
   flex-direction: column;
   gap: $spacing-sm;
@@ -513,12 +629,13 @@ onMounted(() => {
 .registration-input {
   @include input-base;
 
-  &[aria-invalid="true"] {
+  &--invalid {
     border-color: $color-error;
+    background-color: #fef2f2;
 
     &:focus-visible {
       border-color: $color-error;
-      box-shadow: 0 0 0 4px rgba($color-error, 0.2);
+      box-shadow: 0 0 0 4px rgba($color-error, 0.1);
     }
   }
 }
@@ -573,7 +690,6 @@ onMounted(() => {
   border: none;
   padding: 0;
   margin: 0;
-  margin-top: $spacing-lg;
   display: flex;
   flex-direction: column;
   gap: 0.625rem;
@@ -592,8 +708,7 @@ onMounted(() => {
 }
 
 .registration-checkbox {
-  @include custom-radio;
-  border-radius: 4px;
+  @include custom-checkbox;
   margin-top: 2px;
 
   &:focus-visible {
@@ -603,23 +718,6 @@ onMounted(() => {
 
   &[aria-invalid="true"] {
     border-color: $color-error;
-  }
-
-  &:checked {
-    border-color: $color-primary;
-    background-color: $color-primary;
-
-    &::after {
-      content: "✓";
-      color: white;
-      font-size: 12px;
-      font-weight: bold;
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-      background: none;
-    }
   }
 }
 
@@ -650,10 +748,28 @@ onMounted(() => {
 .registration-submit-button {
   @include button-base;
   @include primary-button;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
 
   &[aria-busy="true"] {
-    opacity: 0.7;
     cursor: wait;
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  &__spinner {
+    display: inline-block;
+    width: 1rem;
+    height: 1rem;
+    border: 2px solid rgba(#fff, 0.3);
+    border-top-color: #fff;
+    border-radius: 50%;
+    animation: registration-spin 0.6s linear infinite;
   }
 }
 
@@ -749,5 +865,11 @@ onMounted(() => {
 
 .sr-only {
   @include visually-hidden;
+}
+
+@keyframes registration-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 </style>

--- a/pages/auth/recuperar-contrasena.vue
+++ b/pages/auth/recuperar-contrasena.vue
@@ -2,7 +2,9 @@
   <NuxtLayout name="pacientes-autenticacion">
     <div class="auth-content">
       <div class="auth-header">
-        <h1 class="auth-header__title">Recuperar contraseña</h1>
+        <h1 id="recover-heading" class="auth-header__title">
+          Recuperar contraseña
+        </h1>
         <p v-if="!isSuccess" class="auth-header__subtitle">
           Ingresa tu correo electrónico y te enviaremos instrucciones para
           restablecer tu contraseña
@@ -10,7 +12,11 @@
       </div>
 
       <div v-if="!isSuccess" class="auth-form">
-        <form @submit.prevent="handleSubmit" novalidate>
+        <form
+          @submit.prevent="handleSubmit"
+          novalidate
+          aria-labelledby="recover-heading"
+        >
           <div class="form-group">
             <label for="email" class="form-group__label">
               Correo Electrónico
@@ -30,23 +36,41 @@
               id="email"
               autocomplete="email"
               required
+              aria-required="true"
+              :aria-invalid="touched.email && (!email.trim() || !isEmailValid)"
+              :aria-describedby="
+                touched.email && !email.trim()
+                  ? 'email-error-required'
+                  : touched.email && email.trim() && !isEmailValid
+                    ? 'email-error-invalid'
+                    : undefined
+              "
             />
             <small
               v-if="touched.email && !email.trim()"
+              id="email-error-required"
               class="form-group__error-message"
+              role="alert"
             >
               El correo electrónico es requerido
             </small>
             <small
               v-else-if="touched.email && email.trim() && !isEmailValid"
+              id="email-error-invalid"
               class="form-group__error-message"
+              role="alert"
             >
               Ingresa un correo electrónico válido (ej: usuario@ejemplo.com)
             </small>
           </div>
 
-          <div v-if="errorMessage" class="form-error">
-            <AtomsIconsAlertCircleIcon size="20" />
+          <div
+            v-if="errorMessage"
+            class="form-error"
+            role="alert"
+            aria-live="assertive"
+          >
+            <AtomsIconsAlertCircleIcon size="20" aria-hidden="true" />
             <span>{{ errorMessage }}</span>
           </div>
 
@@ -54,8 +78,9 @@
             type="submit"
             class="form-submit-button"
             :disabled="!isFormValid || isLoading"
+            :aria-busy="isLoading"
           >
-            <span v-if="isLoading" class="spinner"></span>
+            <span v-if="isLoading" class="spinner" aria-hidden="true"></span>
             {{ isLoading ? "Enviando..." : "Enviar instrucciones" }}
           </button>
         </form>
@@ -70,11 +95,19 @@
         </div>
       </div>
 
-      <div v-else class="success-message">
-        <div class="success-message__icon">
+      <div
+        v-else
+        class="success-message"
+        role="status"
+        aria-live="polite"
+        aria-labelledby="success-heading"
+      >
+        <div class="success-message__icon" aria-hidden="true">
           <AtomsIconsCheckIcon size="32" />
         </div>
-        <h2 class="success-message__title">¡Instrucciones enviadas!</h2>
+        <h2 id="success-heading" class="success-message__title">
+          ¡Instrucciones enviadas!
+        </h2>
         <p class="success-message__description">
           Hemos enviado las instrucciones para restablecer tu contraseña a
           <strong>{{ email }}</strong
@@ -105,14 +138,18 @@
 <script lang="ts" setup>
 useSeoMeta({
   title: "Recuperar Contraseña — Vitalink",
-  description: "Restablece tu contraseña de acceso a Vitalink mediante tu correo electrónico.",
+  description:
+    "Restablece tu contraseña de acceso a Vitalink mediante tu correo electrónico.",
   ogTitle: "Recuperar Contraseña — Vitalink",
-  ogDescription: "Restablece tu contraseña de acceso a Vitalink mediante tu correo electrónico.",
+  ogDescription:
+    "Restablece tu contraseña de acceso a Vitalink mediante tu correo electrónico.",
 });
 
 import { useAuth } from "@/composables/api";
+import { useToast } from "@/composables/useToast";
 
 const { forgotPassword } = useAuth();
+const toast = useToast();
 
 const email = ref<string>("");
 const isLoading = ref<boolean>(false);
@@ -153,32 +190,25 @@ const handleSubmit = async () => {
     return;
   }
 
-  try {
-    isLoading.value = true;
-    errorMessage.value = "";
+  isLoading.value = true;
+  errorMessage.value = "";
 
-    const api = forgotPassword({ email: email.value });
-    await api.request();
+  const { error } = await forgotPassword({ email: email.value });
 
-    if (api.error.value) {
-      throw new Error(
-        typeof api.error.value === "string"
-          ? api.error.value
-          : "Error al enviar el correo de recuperación",
-      );
-    }
+  isLoading.value = false;
 
-    isSuccess.value = true;
-  } catch (error) {
-    if (error instanceof Error) {
-      errorMessage.value = error.message;
-    } else {
-      errorMessage.value =
-        "No se pudo enviar el correo de recuperación. Por favor, verifica que el correo electrónico sea correcto e intenta nuevamente.";
-    }
-  } finally {
-    isLoading.value = false;
+  if (error) {
+    const message =
+      error.info ||
+      error.status?.message ||
+      "No se pudo enviar el correo de recuperación. Por favor, verifica que el correo electrónico sea correcto e intenta nuevamente.";
+    errorMessage.value = message;
+    toast.error(message);
+    return;
   }
+
+  isSuccess.value = true;
+  toast.success("Instrucciones enviadas a tu correo electrónico.");
 };
 
 const resetForm = () => {

--- a/pages/verify_forgot_password/[token].vue
+++ b/pages/verify_forgot_password/[token].vue
@@ -2,20 +2,51 @@
   <NuxtLayout name="pacientes-autenticacion">
     <div class="auth-content">
       <div class="auth-header">
-        <h1 class="auth-header__title">Cambiar contraseña</h1>
+        <h1 id="change-password-heading" class="auth-header__title">
+          Cambiar contraseña
+        </h1>
         <p v-if="!isSuccess" class="auth-header__subtitle">
           Ingresa tu nueva contraseña para restablecer el acceso a tu cuenta
         </p>
       </div>
 
-      <div v-if="!isSuccess" class="auth-form">
-        <form @submit.prevent="handleSubmit" novalidate>
+      <div
+        v-if="tokenError"
+        class="token-error"
+        role="alert"
+        aria-labelledby="token-error-heading"
+      >
+        <div class="token-error__icon" aria-hidden="true">
+          <AtomsIconsCircleXIcon size="32" />
+        </div>
+        <h2 id="token-error-heading" class="token-error__title">
+          Enlace inválido o expirado
+        </h2>
+        <p class="token-error__description">
+          El enlace de recuperación es inválido o ha expirado. Por favor,
+          solicita uno nuevo.
+        </p>
+        <NuxtLink to="/auth/recuperar-contrasena" class="token-error__button">
+          Solicitar nuevo enlace
+        </NuxtLink>
+      </div>
+
+      <div v-else-if="!isSuccess" class="auth-form">
+        <form
+          @submit.prevent="handleSubmit"
+          novalidate
+          aria-labelledby="change-password-heading"
+        >
           <div class="form-group">
             <label for="password" class="form-group__label">
               Nueva Contraseña
               <div class="tooltip-container">
-                <AtomsIconsInfoIcon size="16" class="tooltip-trigger" />
-                <div class="tooltip-content">
+                <AtomsIconsInfoIcon
+                  size="16"
+                  class="tooltip-trigger"
+                  aria-hidden="true"
+                />
+                <div class="tooltip-content" role="tooltip">
                   La contraseña debe tener al menos 8 caracteres
                 </div>
               </div>
@@ -35,6 +66,17 @@
                 id="password"
                 autocomplete="new-password"
                 required
+                aria-required="true"
+                :aria-invalid="
+                  touched.password && (!password || !isPasswordValid)
+                "
+                :aria-describedby="
+                  touched.password && !password
+                    ? 'password-error-required'
+                    : touched.password && password && !isPasswordValid
+                      ? 'password-error-invalid'
+                      : undefined
+                "
               />
               <button
                 type="button"
@@ -43,6 +85,7 @@
                 :aria-label="
                   showPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'
                 "
+                :disabled="isLoading"
               >
                 <AtomsIconsEyeIcon v-if="!showPassword" size="20" />
                 <AtomsIconsEyeOffIcon v-else size="20" />
@@ -50,13 +93,17 @@
             </div>
             <small
               v-if="touched.password && !password"
+              id="password-error-required"
               class="form-group__error-message"
+              role="alert"
             >
               La contraseña es requerida
             </small>
             <small
               v-else-if="touched.password && password && !isPasswordValid"
+              id="password-error-invalid"
               class="form-group__error-message"
+              role="alert"
             >
               La contraseña debe tener al menos 8 caracteres
             </small>
@@ -82,6 +129,18 @@
                 id="confirmPassword"
                 autocomplete="new-password"
                 required
+                aria-required="true"
+                :aria-invalid="
+                  touched.confirmPassword &&
+                  (!confirmPassword || passwordMismatch)
+                "
+                :aria-describedby="
+                  touched.confirmPassword && !confirmPassword
+                    ? 'confirm-error-required'
+                    : touched.confirmPassword && passwordMismatch
+                      ? 'confirm-error-mismatch'
+                      : undefined
+                "
               />
               <button
                 type="button"
@@ -92,6 +151,7 @@
                     ? 'Ocultar contraseña'
                     : 'Mostrar contraseña'
                 "
+                :disabled="isLoading"
               >
                 <AtomsIconsEyeIcon v-if="!showConfirmPassword" size="20" />
                 <AtomsIconsEyeOffIcon v-else size="20" />
@@ -99,61 +159,81 @@
             </div>
             <small
               v-if="touched.confirmPassword && !confirmPassword"
+              id="confirm-error-required"
               class="form-group__error-message"
+              role="alert"
             >
               Debes confirmar tu contraseña
             </small>
             <small
               v-else-if="touched.confirmPassword && passwordMismatch"
+              id="confirm-error-mismatch"
               class="form-group__error-message"
+              role="alert"
             >
               Las contraseñas no coinciden
             </small>
           </div>
 
-          <div class="password-requirements">
-            <p class="password-requirements__title">
+          <div
+            class="password-requirements"
+            aria-label="Requisitos de contraseña"
+          >
+            <p class="password-requirements__title" aria-hidden="true">
               La contraseña debe cumplir con:
             </p>
             <ul class="password-requirements__list">
               <li
                 class="password-requirements__item"
                 :class="{ 'is-valid': password.length >= 8 }"
+                :aria-label="`Mínimo 8 caracteres: ${password.length >= 8 ? 'cumplido' : 'pendiente'}`"
               >
-                <AtomsIconsCheckIcon v-if="password.length >= 8" size="16" />
-                <AtomsIconsXIcon v-else size="16" />
-                Mínimo 8 caracteres
+                <AtomsIconsCheckIcon
+                  v-if="password.length >= 8"
+                  size="16"
+                  aria-hidden="true"
+                />
+                <AtomsIconsXIcon v-else size="16" aria-hidden="true" />
+                <span aria-hidden="true">Mínimo 8 caracteres</span>
               </li>
               <li
                 class="password-requirements__item"
                 :class="{ 'is-valid': hasUpperCase }"
+                :aria-label="`Al menos una mayúscula: ${hasUpperCase ? 'cumplido' : 'pendiente'}`"
               >
-                <AtomsIconsCheckIcon v-if="hasUpperCase" size="16" />
-                <AtomsIconsXIcon v-else size="16" />
-                Al menos una mayúscula (recomendado)
+                <AtomsIconsCheckIcon
+                  v-if="hasUpperCase"
+                  size="16"
+                  aria-hidden="true"
+                />
+                <AtomsIconsXIcon v-else size="16" aria-hidden="true" />
+                <span aria-hidden="true"
+                  >Al menos una mayúscula (recomendado)</span
+                >
               </li>
               <li
                 class="password-requirements__item"
                 :class="{ 'is-valid': hasNumber }"
+                :aria-label="`Al menos un número: ${hasNumber ? 'cumplido' : 'pendiente'}`"
               >
-                <AtomsIconsCheckIcon v-if="hasNumber" size="16" />
-                <AtomsIconsXIcon v-else size="16" />
-                Al menos un número (recomendado)
+                <AtomsIconsCheckIcon
+                  v-if="hasNumber"
+                  size="16"
+                  aria-hidden="true"
+                />
+                <AtomsIconsXIcon v-else size="16" aria-hidden="true" />
+                <span aria-hidden="true">Al menos un número (recomendado)</span>
               </li>
             </ul>
-          </div>
-
-          <div v-if="errorMessage" class="form-error">
-            <AtomsIconsAlertCircleIcon size="20" />
-            <span>{{ errorMessage }}</span>
           </div>
 
           <button
             type="submit"
             class="form-submit-button"
             :disabled="!isFormValid || isLoading"
+            :aria-busy="isLoading"
           >
-            <span v-if="isLoading" class="spinner"></span>
+            <span v-if="isLoading" class="spinner" aria-hidden="true"></span>
             {{ isLoading ? "Cambiando contraseña..." : "Cambiar contraseña" }}
           </button>
         </form>
@@ -167,11 +247,17 @@
         </div>
       </div>
 
-      <div v-else class="success-message">
-        <div class="success-message__icon">
+      <div
+        v-else
+        class="success-message"
+        role="status"
+        aria-live="polite"
+        aria-labelledby="success-heading"
+      >
+        <div class="success-message__icon" aria-hidden="true">
           <AtomsIconsCheckIcon size="32" />
         </div>
-        <h2 class="success-message__title">
+        <h2 id="success-heading" class="success-message__title">
           ¡Contraseña cambiada exitosamente!
         </h2>
         <p class="success-message__description">
@@ -194,13 +280,16 @@ useSeoMeta({
   title: "Cambiar Contraseña — Vitalink",
   description: "Actualiza tu contraseña de acceso a Vitalink de forma segura.",
   ogTitle: "Cambiar Contraseña — Vitalink",
-  ogDescription: "Actualiza tu contraseña de acceso a Vitalink de forma segura.",
+  ogDescription:
+    "Actualiza tu contraseña de acceso a Vitalink de forma segura.",
 });
 
 import { useAuth } from "@/composables/api";
+import { useToast } from "@/composables/useToast";
 
 const route = useRoute();
 const { resetPassword, verifyForgotPasswordToken } = useAuth();
+const toast = useToast();
 
 const password = ref<string>("");
 const confirmPassword = ref<string>("");
@@ -208,47 +297,37 @@ const showPassword = ref<boolean>(false);
 const showConfirmPassword = ref<boolean>(false);
 const isLoading = ref<boolean>(false);
 const isSuccess = ref<boolean>(false);
-const errorMessage = ref<string>("");
 const isVerifyingToken = ref<boolean>(true);
+const tokenError = ref<boolean>(false);
 
 const touched = reactive({
   password: false,
   confirmPassword: false,
 });
 
-const token = computed(() => {
-  return (route.query.token as string) || "";
-});
+const token = computed(() => (route.params.token as string) || "");
 
-const isPasswordValid = computed(() => {
-  return password.value.length >= 8;
-});
+const isPasswordValid = computed(() => password.value.length >= 8);
 
-const hasUpperCase = computed(() => {
-  return /[A-Z]/.test(password.value);
-});
+const hasUpperCase = computed(() => /[A-Z]/.test(password.value));
 
-const hasNumber = computed(() => {
-  return /\d/.test(password.value);
-});
+const hasNumber = computed(() => /\d/.test(password.value));
 
-const passwordMismatch = computed(() => {
-  return (
+const passwordMismatch = computed(
+  () =>
     password.value.trim() !== "" &&
     password.value !== confirmPassword.value &&
-    confirmPassword.value !== ""
-  );
-});
+    confirmPassword.value !== "",
+);
 
-const isFormValid = computed(() => {
-  return (
+const isFormValid = computed(
+  () =>
     password.value.trim() !== "" &&
     confirmPassword.value.trim() !== "" &&
     isPasswordValid.value &&
     !passwordMismatch.value &&
-    token.value !== ""
-  );
-});
+    token.value !== "",
+);
 
 const markAllTouched = () => {
   Object.keys(touched).forEach((key) => {
@@ -258,32 +337,23 @@ const markAllTouched = () => {
 
 const verifyToken = async () => {
   if (!token.value) {
-    errorMessage.value =
-      "Token de recuperación no encontrado. Por favor, utiliza el enlace enviado a tu correo electrónico.";
     isVerifyingToken.value = false;
+    tokenError.value = true;
+    toast.error(
+      "Token de recuperación no encontrado. Por favor, utiliza el enlace enviado a tu correo electrónico.",
+    );
     return;
   }
 
-  try {
-    const api = verifyForgotPasswordToken(token.value);
-    await api.request();
+  const { data, error } = await verifyForgotPasswordToken(token.value);
 
-    if (api.error.value) {
-      throw new Error("Token inválido o expirado");
-    }
+  isVerifyingToken.value = false;
 
-    const response = api.response.value;
-    if (response && !response.data?.valid) {
-      throw new Error(response.data?.message || "Token inválido o expirado");
-    }
-
-    isVerifyingToken.value = false;
-  } catch (error) {
-    isVerifyingToken.value = false;
-    errorMessage.value =
-      error instanceof Error
-        ? error.message
-        : "Token de recuperación inválido o expirado. Por favor, solicita un nuevo enlace de recuperación.";
+  if (error || !data?.valid) {
+    tokenError.value = true;
+    toast.error(
+      "El enlace de recuperación es inválido o ha expirado. Por favor, solicita uno nuevo.",
+    );
   }
 };
 
@@ -295,43 +365,33 @@ const handleSubmit = async () => {
   }
 
   if (!token.value) {
-    errorMessage.value =
-      "Token de recuperación inválido o expirado. Por favor, solicita un nuevo enlace de recuperación.";
+    toast.error(
+      "Token de recuperación inválido o expirado. Por favor, solicita un nuevo enlace de recuperación.",
+    );
     return;
   }
 
-  try {
-    isLoading.value = true;
-    errorMessage.value = "";
+  isLoading.value = true;
 
-    const api = resetPassword(token.value, {
-      password: password.value,
-    });
-    await api.request();
+  const { error } = await resetPassword(token.value, {
+    password: password.value,
+  });
 
-    if (api.error.value) {
-      throw new Error(
-        typeof api.error.value === "string"
-          ? api.error.value
-          : "Error al cambiar la contraseña",
-      );
-    }
+  isLoading.value = false;
 
-    isSuccess.value = true;
-
-    setTimeout(() => {
-      navigateTo("/auth/login");
-    }, 3000);
-  } catch (error) {
-    if (error instanceof Error) {
-      errorMessage.value = error.message;
-    } else {
-      errorMessage.value =
-        "No se pudo cambiar la contraseña. Por favor, intenta nuevamente o solicita un nuevo enlace de recuperación.";
-    }
-  } finally {
-    isLoading.value = false;
+  if (error) {
+    toast.error(
+      "No se pudo cambiar la contraseña. Por favor, intenta nuevamente o solicita un nuevo enlace de recuperación.",
+    );
+    return;
   }
+
+  isSuccess.value = true;
+  toast.success("¡Contraseña cambiada exitosamente!");
+
+  setTimeout(() => {
+    navigateTo("/auth/login");
+  }, 3000);
 };
 
 onMounted(async () => {
@@ -450,6 +510,11 @@ onMounted(async () => {
     outline: 2px solid $color-primary;
     outline-offset: 2px;
   }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.4;
+  }
 }
 
 .tooltip-container {
@@ -566,19 +631,6 @@ onMounted(async () => {
   }
 }
 
-.form-error {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.75rem 1rem;
-  background-color: #fef2f2;
-  border: 1px solid #fecaca;
-  border-radius: 0.5rem;
-  color: #dc2626;
-  font-size: 0.875rem;
-  margin-top: 1rem;
-}
-
 .form-submit-button {
   @include primary-button;
   width: 100%;
@@ -630,6 +682,12 @@ onMounted(async () => {
     &:hover {
       text-decoration: underline;
       color: $color-primary-darkened-10;
+    }
+
+    &:focus-visible {
+      outline: 2px solid $color-primary;
+      outline-offset: 2px;
+      border-radius: 2px;
     }
   }
 }
@@ -687,6 +745,56 @@ onMounted(async () => {
     display: flex;
     align-items: center;
     justify-content: center;
+  }
+}
+
+.token-error {
+  text-align: center;
+  padding: 1rem 0;
+
+  &__icon {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 4.5rem;
+    height: 4.5rem;
+    background: linear-gradient(135deg, #fee2e2 0%, #fecaca 100%);
+    border-radius: 50%;
+    margin: 0 auto 1.5rem;
+
+    svg {
+      color: #dc2626;
+    }
+  }
+
+  &__title {
+    @include label-base;
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: $color-foreground;
+    margin-bottom: 1rem;
+
+    @media (max-width: 48rem) {
+      font-size: 1.5rem;
+    }
+  }
+
+  &__description {
+    @include text-base;
+    font-size: 1rem;
+    color: $color-text-muted;
+    line-height: 1.7;
+    margin: 0 0 2rem 0;
+  }
+
+  &__button {
+    @include primary-button;
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding-left: 2rem;
+    padding-right: 2rem;
   }
 }
 </style>


### PR DESCRIPTION
- Add document type and number fields to patient registration form with formatting and validation via useFormat composable
- Rename cambiar-contrasena page to verify_forgot_password/[token] so the reset token is a path param instead of a query param
- Add token expiry error state with dedicated UI on the password change page
- Migrate inline error messages to toast notifications across auth forms
- Extract custom-checkbox mixin and add registration-input--invalid modifier
- Improve ARIA roles, live regions, and labeled controls across auth pages