### PR TITLE
Simplify registration flows, remove social login, and add pending-approval state

### DIFF
--- a/components/pacientes/registro/formulario-registro-correo.vue
+++ b/components/pacientes/registro/formulario-registro-correo.vue
@@ -268,34 +268,6 @@
       </fieldset>
     </form>
 
-    <div
-      class="registration-social-login"
-      role="region"
-      aria-label="Opciones de registro social"
-    >
-      <p class="registration-social-login__label">
-        <span>O hacerlo con:</span>
-      </p>
-      <div class="registration-social-buttons">
-        <button
-          type="button"
-          class="registration-social-button registration-google-button"
-          aria-label="Registrarse con Google"
-          @click="loginWithGoogle"
-        >
-          <AtomsIconsGoogleIcon size="24" aria-hidden="true" />
-        </button>
-        <button
-          type="button"
-          class="registration-social-button registration-apple-button"
-          aria-label="Registrarse con Apple"
-          @click="loginWithApple"
-        >
-          <AtomsIconsAppleIcon size="24" aria-hidden="true" />
-        </button>
-      </div>
-    </div>
-
     <div class="registration-footer-actions">
       <p class="registration-already-account">
         <span>¿Ya tienes una cuenta?</span>
@@ -530,12 +502,9 @@ const handleSubmit = async () => {
     }
 
     if (data.value) {
-      await useFetch(config.public.API_BASE_URL + "/forgot_password", {
-        method: "POST",
-        body: { email: email.value },
-      });
-
-      toast.success("Registro exitoso. Revisa tu correo electrónico para verificar tu cuenta.");
+      toast.success(
+        "Registro exitoso. Revisa tu correo electrónico para verificar tu cuenta.",
+      );
     }
   } catch (error) {
     logger.error("Register exception", { error });

--- a/pages/auth/login.vue
+++ b/pages/auth/login.vue
@@ -106,21 +106,6 @@
             ¿Olvidaste tu contraseña?
           </NuxtLink>
         </div>
-
-        <div class="social-login">
-          <p class="social-login__divider" aria-hidden="true">
-            <span>O hacerlo con</span>
-          </p>
-          <button
-            type="button"
-            class="social-login__button"
-            aria-label="Ingresar con Google"
-            :disabled="isLoading"
-          >
-            <AtomsIconsGoogleIcon aria-hidden="true" />
-            <span>Ingresar con Google</span>
-          </button>
-        </div>
       </div>
 
       <div class="login-form__footer">

--- a/pages/confirmation_register/[token].vue
+++ b/pages/confirmation_register/[token].vue
@@ -1,55 +1,63 @@
 <template>
   <div class="auth-content">
-      <div v-if="isLoading" class="verification-state">
-        <div class="verification-state__spinner">
-          <span class="spinner spinner--large"></span>
-        </div>
-        <h1 class="verification-state__title">Verificando tu cuenta</h1>
-        <p class="verification-state__description">
-          Estamos confirmando tu registro, por favor espera un momento...
-        </p>
+    <div v-if="isLoading" class="verification-state">
+      <div class="verification-state__spinner">
+        <span class="spinner spinner--large"></span>
       </div>
+      <h1 class="verification-state__title">Verificando tu cuenta</h1>
+      <p class="verification-state__description">
+        Estamos confirmando tu registro, por favor espera un momento...
+      </p>
+    </div>
 
-      <div v-else-if="isSuccess" class="success-message">
-        <div class="success-message__icon">
-          <AtomsIconsCheckIcon size="32" />
-        </div>
-        <h1 class="success-message__title">¡Cuenta verificada!</h1>
-        <p class="success-message__description">
-          Tu cuenta ha sido confirmada exitosamente. Ya puedes iniciar sesión y
-          comenzar a usar Vitalink.
-        </p>
-        <p class="success-message__note">
-          Serás redirigido al inicio de sesión automáticamente en unos segundos.
-        </p>
-        <div class="success-message__actions">
-          <NuxtLink to="/pacientes/login" class="success-message__button">
-            Ir a iniciar sesión
-          </NuxtLink>
-        </div>
+    <div v-else-if="isSuccess && isPendingApproval" class="pending-message">
+      <div class="pending-message__icon">
+        <AtomsIconsCheckIcon size="32" />
       </div>
+      <h1 class="pending-message__title">¡Correo verificado!</h1>
+      <p class="pending-message__description">
+        Tu dirección de correo ha sido confirmada. Espera que Vitalink confirme
+        tu registro antes de poder acceder a tu cuenta.
+      </p>
+      <p class="pending-message__note">
+        Recibirás una notificación cuando tu cuenta haya sido aprobada.
+      </p>
+    </div>
 
-      <div v-else class="error-message">
-        <div class="error-message__icon">
-          <AtomsIconsCircleXIcon size="32" />
-        </div>
-        <h1 class="error-message__title">Verificación fallida</h1>
-        <p class="error-message__description">
-          {{ errorMessage }}
-        </p>
-        <div class="error-message__actions">
-          <NuxtLink to="/pacientes/registro" class="error-message__button">
-            Volver al registro
-          </NuxtLink>
-          <NuxtLink
-            to="/pacientes/login"
-            class="error-message__button-secondary"
-          >
-            Ir a iniciar sesión
-          </NuxtLink>
-        </div>
+    <div v-else-if="isSuccess" class="success-message">
+      <div class="success-message__icon">
+        <AtomsIconsCheckIcon size="32" />
+      </div>
+      <h1 class="success-message__title">¡Cuenta verificada!</h1>
+      <p class="success-message__description">
+        Tu cuenta ha sido confirmada exitosamente. Ya puedes iniciar sesión y
+        comenzar a usar Vitalink.
+      </p>
+      <div class="success-message__actions">
+        <NuxtLink to="/pacientes/login" class="success-message__button">
+          Ir a iniciar sesión
+        </NuxtLink>
       </div>
     </div>
+
+    <div v-else class="error-message">
+      <div class="error-message__icon">
+        <AtomsIconsCircleXIcon size="32" />
+      </div>
+      <h1 class="error-message__title">Verificación fallida</h1>
+      <p class="error-message__description">
+        {{ errorMessage }}
+      </p>
+      <div class="error-message__actions">
+        <NuxtLink to="/pacientes/registro" class="error-message__button">
+          Volver al registro
+        </NuxtLink>
+        <NuxtLink to="/pacientes/login" class="error-message__button-secondary">
+          Ir a iniciar sesión
+        </NuxtLink>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script lang="ts" setup>
@@ -61,6 +69,8 @@ useSeoMeta({
 });
 
 import { useAuth } from "@/composables/api";
+import { decodeJWT } from "@/utils/jwt";
+import { UserRole } from "@/types/auth";
 
 const route = useRoute();
 const { confirmationRegister } = useAuth();
@@ -72,6 +82,15 @@ const errorMessage = ref<string>(
 );
 
 const token = computed(() => (route.params.token as string) || "");
+
+const isPendingApproval = computed(() => {
+  if (!token.value) return false;
+  const payload = decodeJWT(token.value);
+  return (
+    payload?.role === UserRole.LEGAL_REPRESENTATIVE ||
+    payload?.role === UserRole.FINANCE_ENTITY
+  );
+});
 
 onMounted(async () => {
   if (!token.value) {
@@ -93,10 +112,6 @@ onMounted(async () => {
 
   isSuccess.value = true;
   isLoading.value = false;
-
-  setTimeout(() => {
-    navigateTo("/pacientes/login");
-  }, 4000);
 });
 </script>
 
@@ -161,6 +176,58 @@ onMounted(async () => {
 @keyframes spin {
   to {
     transform: rotate(360deg);
+  }
+}
+
+.pending-message {
+  text-align: center;
+  padding: 1rem 0;
+
+  &__icon {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 4.5rem;
+    height: 4.5rem;
+    background: linear-gradient(135deg, #fef9c3 0%, #fde68a 100%);
+    border-radius: 50%;
+    margin: 0 auto 1.5rem;
+
+    svg {
+      color: #b45309;
+    }
+  }
+
+  &__title {
+    @include label-base;
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: $color-foreground;
+    margin-bottom: 1rem;
+
+    @media (max-width: 48rem) {
+      font-size: 1.5rem;
+    }
+  }
+
+  &__description {
+    @include text-base;
+    font-size: 1rem;
+    color: $color-text-muted;
+    line-height: 1.7;
+    margin: 0 0 1rem 0;
+  }
+
+  &__note {
+    @include text-base;
+    font-size: 0.875rem;
+    color: $color-text-muted;
+    line-height: 1.5;
+    margin: 0;
+    padding: 1rem;
+    background-color: #fffbeb;
+    border-radius: 0.5rem;
+    border-left: 3px solid #f59e0b;
   }
 }
 

--- a/pages/medicos/registro.vue
+++ b/pages/medicos/registro.vue
@@ -1,22 +1,49 @@
 <template>
   <NuxtLayout name="medicos-autenticacion">
     <section class="registration" aria-labelledby="registration-heading">
-      <HeaderRegistro />
+      <template v-if="!registrationComplete">
+        <HeaderRegistro />
 
-      <form
-        @submit.prevent="submitRegistration"
-        class="registration__form"
-        novalidate
-      >
-        <div class="registration__step">
-          <MedicosRegistroFormularioProveedorMedico
-            :form-data="representativeFormData"
-            :is-submitting="isSubmitting"
-            @update:form-data="representativeFormData = $event"
-            @submit="submitRegistration"
-          />
+        <form
+          @submit.prevent="submitRegistration"
+          class="registration__form"
+          novalidate
+        >
+          <div class="registration__step">
+            <MedicosRegistroFormularioProveedorMedico
+              :form-data="representativeFormData"
+              :is-submitting="isSubmitting"
+              @update:form-data="representativeFormData = $event"
+              @submit="submitRegistration"
+            />
+          </div>
+        </form>
+      </template>
+
+      <div v-else class="registration__confirmation">
+        <div class="confirmation-message">
+          <div class="confirmation-message__icon" aria-hidden="true">
+            <AtomsIconsCheckIcon size="32" />
+          </div>
+          <h1 class="confirmation-message__title">
+            ¡Registro completado!
+          </h1>
+          <p class="confirmation-message__description">
+            Tu cuenta ha sido creada exitosamente. Te hemos enviado un correo
+            electrónico a <strong>{{ representativeFormData.email }}</strong> con
+            un enlace para confirmar tu dirección.
+          </p>
+          <p class="confirmation-message__note">
+            Por favor revisa tu bandeja de entrada (y carpeta de spam) y sigue
+            las instrucciones del correo para activar tu cuenta.
+          </p>
+          <div class="confirmation-message__actions">
+            <NuxtLink to="/medicos/login" class="confirmation-message__button">
+              Ir a iniciar sesión
+            </NuxtLink>
+          </div>
         </div>
-      </form>
+      </div>
     </section>
   </NuxtLayout>
 </template>
@@ -29,22 +56,17 @@ useSeoMeta({
   ogDescription: "Regístrate como proveedor de salud en la plataforma Vitalink.",
 });
 
-import { useAuth, useDocuments } from "@/composables/api";
+import { useAuth } from "@/composables/api";
 import { useFormat } from "@/composables/useFormat";
 import { useLogger } from "@/composables/useLogger";
-import { getUserIdFromToken } from "@/utils/jwt";
 
-const { register, login, getUserById } = useAuth();
-const { addDocument } = useDocuments();
+const { register } = useAuth();
 const { convertCedulaForBackend } = useFormat();
-const { setAuthenticated, setRole } = useAuthState();
-const { setToken, setRefreshToken, getToken } = useAuthToken();
-const { setUserInfo } = useUserInfo();
 const toast = useToast();
-const router = useRouter();
 const logger = useLogger("RegistroMedico");
 
 const isSubmitting = ref(false);
+const registrationComplete = ref(false);
 
 const representativeFormData = ref<IRepresentativeRegisterRequest>({
   documentType: "",
@@ -69,224 +91,53 @@ const submitRegistration = async (): Promise<void> => {
   isSubmitting.value = true;
 
   try {
-    const representativeId = await registerRepresentative();
-    const { accessToken, userId } = await authenticateRepresentative();
-    const contractCode = await uploadContract(formData.contractFile);
-    await linkContractToUser(userId, contractCode);
+    const backendDocumentNumber = convertCedulaForBackend(
+      formData.documentNumber,
+      formData.documentType,
+    );
 
-    localStorage.setItem("onboarding", "true");
-    toast.success("¡Registro completado exitosamente!");
-    await router.push("/medicos/mis-medicos");
+    const { data, error } = await register({
+      card_id: backendDocumentNumber,
+      id_type: formData.documentType,
+      name: formData.fullName,
+      email: formData.email,
+      password: formData.password,
+      gender: "M",
+      role_code: "LEGAL_REPRESENTATIVE",
+      phone_number: formData.phone,
+      country_iso_code: "",
+      province: "",
+      city_name: "",
+      address: "",
+      postal_code: "",
+      birth_date: "",
+      profile_picture_url: "",
+    });
+
+    if (error) {
+      const isDuplicate =
+        error.status?.http_code === 409 ||
+        error.info?.toLowerCase().includes("duplicate entry") ||
+        error.info?.toLowerCase().includes("ya existe");
+
+      toast.error(
+        isDuplicate
+          ? "Este usuario ya está registrado. Por favor inicia sesión."
+          : error.info || "Error al registrar el representante legal.",
+      );
+      return;
+    }
+
+    logger.debug("Representative registered", { id: (data as any)?.id });
+    registrationComplete.value = true;
   } catch (error) {
-    handleRegistrationError(error);
+    logger.error("Registration failed", { error });
+    toast.error("Error en el registro. Intenta nuevamente.");
   } finally {
     isSubmitting.value = false;
   }
 };
 
-const registerRepresentative = async (): Promise<string> => {
-  const formData = representativeFormData.value;
-
-  const backendDocumentNumber = convertCedulaForBackend(
-    formData.documentNumber,
-    formData.documentType,
-  );
-
-  const { data, error } = await register({
-    card_id: backendDocumentNumber,
-    id_type: formData.documentType,
-    name: formData.fullName,
-    email: formData.email,
-    password: formData.password,
-    gender: "M",
-    role_code: "LEGAL_REPRESENTATIVE",
-    phone_number: formData.phone,
-    country_iso_code: "",
-    province: "",
-    city_name: "",
-    address: "",
-    postal_code: "",
-    birth_date: "",
-    profile_picture_url: "",
-  });
-
-  if (error) {
-    const isDuplicate =
-      error.status?.http_code === 409 ||
-      error.info?.toLowerCase().includes("duplicate entry") ||
-      error.info?.toLowerCase().includes("ya existe");
-
-    if (isDuplicate) {
-      throw createRegistrationError(
-        "Este usuario ya está registrado. Por favor inicia sesión.",
-        409,
-      );
-    }
-
-    throw createRegistrationError(
-      error.info || "Error al registrar el representante legal.",
-      error.status?.http_code,
-    );
-  }
-
-  const representativeId = (data as any)?.id;
-
-  if (!representativeId) {
-    throw createRegistrationError(
-      "No se pudo obtener el ID del representante legal.",
-      500,
-    );
-  }
-
-  logger.debug("Representative registered", { representativeId });
-  return representativeId;
-};
-
-const authenticateRepresentative = async (): Promise<{
-  accessToken: string;
-  userId: string;
-}> => {
-  const formData = representativeFormData.value;
-
-  const { data, error } = await login({
-    email: formData.email,
-    password: formData.password,
-  });
-
-  if (error || !data) {
-    throw createRegistrationError(
-      "No se pudo iniciar sesión automáticamente.",
-      error?.status?.http_code,
-    );
-  }
-
-  const { access_token, refresh_token } = data;
-
-  setAuthenticated(true);
-  setToken(access_token);
-  setRefreshToken(refresh_token);
-  setRole("LEGAL_REPRESENTATIVE");
-
-  const userId = getUserIdFromToken(access_token);
-
-  if (!userId) {
-    throw createRegistrationError(
-      "No se pudo obtener el ID del usuario del token.",
-      500,
-    );
-  }
-
-  await loadUserProfile(userId, access_token);
-
-  logger.debug("Representative authenticated", { userId });
-  return { accessToken: access_token, userId };
-};
-
-const loadUserProfile = async (
-  userId: string,
-  accessToken: string,
-): Promise<void> => {
-  const { data, error } = await getUserById(userId, accessToken);
-
-  if (data) {
-    setUserInfo(data);
-  } else if (error) {
-    logger.warn("Could not load user profile", { error: error.info });
-  }
-};
-
-const uploadContract = async (file: File): Promise<string> => {
-  const { data, error } = await addDocument({
-    file,
-    fields: {
-      title: file.name,
-      type: "DOC",
-      description: "Contrato cargado durante el registro médico",
-      id_for_table: "6",
-      table: "",
-      action_type: "PRIVATE_CONTRACT",
-      user_id: "",
-      is_public: 0,
-    },
-  });
-
-  if (error || !data) {
-    throw createRegistrationError(
-      error?.info || "Error al subir el contrato.",
-      error?.status?.http_code,
-    );
-  }
-
-  const contractCode = data.code;
-
-  if (!contractCode) {
-    throw createRegistrationError(
-      "No se pudo obtener el código del contrato.",
-      500,
-    );
-  }
-
-  logger.debug("Contract uploaded", { contractCode });
-  return contractCode;
-};
-
-const linkContractToUser = async (
-  userId: string,
-  contractCode: string,
-): Promise<void> => {
-  const config = useRuntimeConfig();
-  const token = getToken();
-
-  if (!token) {
-    throw createRegistrationError("Token de autenticación no disponible.", 401);
-  }
-
-  try {
-    await $fetch(`user/edit`, {
-      baseURL: `${config.public.API_BASE_URL}/`,
-      method: "PUT",
-      headers: { Authorization: token },
-      query: { id: userId },
-      body: { code_contract: contractCode },
-    });
-
-    logger.debug("Contract linked to user", { userId, contractCode });
-  } catch {
-    throw createRegistrationError(
-      "Error al vincular el contrato con el usuario.",
-      500,
-    );
-  }
-};
-
-interface RegistrationError {
-  message: string;
-  httpCode?: number;
-}
-
-const createRegistrationError = (
-  message: string,
-  httpCode?: number,
-): RegistrationError => ({
-  message,
-  httpCode,
-});
-
-const handleRegistrationError = (error: unknown): void => {
-  const registrationError = error as RegistrationError;
-  let errorMessage = "Error en el registro. Intenta nuevamente.";
-
-  if (registrationError?.message) {
-    errorMessage = registrationError.message;
-  }
-
-  logger.error("Registration failed", {
-    message: errorMessage,
-    httpCode: registrationError?.httpCode,
-  });
-
-  toast.error(errorMessage);
-};
 </script>
 
 <style lang="scss" scoped>
@@ -308,6 +159,73 @@ const handleRegistrationError = (error: unknown): void => {
     display: flex;
     flex-direction: column;
     width: 100%;
+  }
+
+  &__confirmation {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+}
+
+.confirmation-message {
+  text-align: center;
+  padding: 1rem 0;
+
+  &__icon {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 4.5rem;
+    height: 4.5rem;
+    background: linear-gradient(135deg, #d3f2dd 0%, #a7e9ba 100%);
+    border-radius: 50%;
+    margin: 0 auto 1.5rem;
+
+    svg {
+      color: #0e7d3a;
+    }
+  }
+
+  &__title {
+    font-family: $font-family-main;
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: $color-foreground;
+    margin-bottom: 1rem;
+  }
+
+  &__description {
+    font-family: $font-family-main;
+    font-size: 1rem;
+    color: $color-text-muted;
+    line-height: 1.7;
+    margin: 0 0 1rem 0;
+  }
+
+  &__note {
+    font-family: $font-family-main;
+    font-size: 0.875rem;
+    color: $color-text-secondary;
+    line-height: 1.5;
+    margin: 0 0 2rem 0;
+    padding: 1rem;
+    background-color: #fffbeb;
+    border-radius: 0.5rem;
+    border-left: 3px solid #f59e0b;
+  }
+
+  &__actions {
+    margin-top: 2rem;
+  }
+
+  &__button {
+    @include primary-button;
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
   }
 }
 </style>

--- a/pages/pacientes/login.vue
+++ b/pages/pacientes/login.vue
@@ -54,23 +54,6 @@
             {{ passwordError }}
           </span>
         </div>
-
-        <div class="text-center d-flex flex-column">
-          <div class="social-login">
-            <p class="social-login__label" id="social-login-label">
-              <small>O hacerlo con:</small>
-            </p>
-            <button
-              type="button"
-              class="social-login__button"
-              aria-labelledby="social-login-label google-login-label"
-              :disabled="isLoading"
-            >
-              <AtomsIconsGoogleIcon />
-              <span id="google-login-label">Ingresar con Google</span>
-            </button>
-          </div>
-        </div>
       </div>
 
       <div class="login-form__footer">
@@ -108,16 +91,22 @@ useSeoMeta({
   ogDescription: "Accede a tu cuenta de paciente en Vitalink.",
 });
 
-import { useAuth, useSupplier } from "@/composables/api";
+import { useAuth } from "@/composables/api";
+import {
+  type DecodedToken,
+  type LoginResponse,
+  type UserRoleType,
+  ROLE_HOME_ROUTES,
+  ROLES_REQUIRING_PROFILE,
+} from "@/types/auth";
 import { jwtDecode } from "jwt-decode";
 
 definePageMeta({
   middleware: ["auth-login"],
 });
 
-const { login, fetchUserInfo, fetchHospitalInfo } = useAuth();
+const { login, getUserById } = useAuth();
 const { setUserInfo } = useUserInfo();
-const { fetchSupplier } = useSupplier();
 const { setRole, setAuthenticated } = useAuthState();
 const { setToken, setRefreshToken } = useAuthToken();
 const router = useRouter();
@@ -129,38 +118,26 @@ const isLoading = ref<boolean>(false);
 const emailError = ref<string>("");
 const passwordError = ref<string>("");
 
-interface DecodedToken {
-  id: string;
-  role: string;
-}
-
 const handleLogin = async () => {
   try {
     isLoading.value = true;
     clearErrors();
 
-    const formData = {
+    const { data, error } = await login({
       email: email.value,
-      username: "",
       password: password.value,
-    };
-
-    const api = login(formData);
-    await api.request();
-
-    const response = api.response.value;
-    const error = api.error.value;
+    });
 
     if (error) {
       handleLoginError(error);
       return;
     }
 
-    if (response?.data) {
-      await handleSuccessfulLogin(response.data);
+    if (data) {
+      await handleSuccessfulLogin(data as LoginResponse);
     }
-  } catch (error) {
-    console.error("Login error:", error);
+  } catch (err) {
+    console.error("Login error:", err);
   } finally {
     isLoading.value = false;
   }
@@ -171,8 +148,9 @@ const clearErrors = () => {
   passwordError.value = "";
 };
 
-const handleLoginError = (error: any) => {
-  const errorInfo = error.info || error.message || "Error al iniciar sesión";
+const handleLoginError = (error: IApiErrorResponse) => {
+  const errorInfo =
+    error.info || error.status?.message || "Error al iniciar sesión";
 
   if (errorInfo.toLowerCase().includes("password")) {
     passwordError.value = errorInfo;
@@ -186,96 +164,43 @@ const handleLoginError = (error: any) => {
   }
 };
 
-const handleSuccessfulLogin = async (data: any) => {
-  const accessToken = data.access_token;
-  const refreshToken = data.refresh_token;
+const handleSuccessfulLogin = async (data: LoginResponse) => {
+  const { access_token, refresh_token } = data;
 
-  setToken(accessToken);
-  setRefreshToken(refreshToken);
+  setToken(access_token);
+  setRefreshToken(refresh_token);
   setAuthenticated(true);
 
-  const decodedToken = jwtDecode<DecodedToken>(accessToken);
-  setRole(decodedToken.role);
+  const decoded = jwtDecode<DecodedToken>(access_token);
+  setRole(decoded.role);
 
-  await routeUserByRole(decodedToken, accessToken);
+  await loadUserProfile(decoded, access_token);
+  navigateToHome(decoded.role);
 };
 
-const routeUserByRole = async (decodedToken: DecodedToken, token: string) => {
-  const { id, role } = decodedToken;
+const loadUserProfile = async (decoded: DecodedToken, token: string) => {
+  if (!ROLES_REQUIRING_PROFILE.has(decoded.role)) {
+    setUserInfo(decoded);
+    return;
+  }
 
-  switch (role) {
-    case "CUSTOMER":
-      await getUserInfo(id, token);
-      break;
-    case "LEGAL_REPRESENTATIVE":
-      await getDoctorInfo(id, token);
-      break;
-    case "FINANCE_ENTITY":
-      await getFinanceEntityInfo(decodedToken);
-      break;
-    default:
-      await getHospitalInfo(token);
-      break;
+  const { data, error } = await getUserById(decoded.id, token);
+
+  if (error) {
+    console.error("Error al obtener perfil:", error);
+    return;
+  }
+
+  if (data) {
+    setUserInfo(data);
   }
 };
 
-const getUserInfo = async (userId: string, token: string) => {
-  try {
-    const api = fetchUserInfo(userId, token);
-    await api.request();
-
-    const response = api.response.value;
-    const error = api.error.value;
-
-    if (error) {
-      console.error("Error fetching user info:", error);
-      return;
-    }
-
-    if (response?.data) {
-      setUserInfo(response.data);
-      router.push("/pacientes/inicio");
-    }
-  } catch (err) {
-    console.error("Error en getUserInfo:", err);
+const navigateToHome = (role: UserRoleType) => {
+  const route = ROLE_HOME_ROUTES[role];
+  if (route) {
+    router.push(route);
   }
-};
-
-const getDoctorInfo = async (userId: string, token: string) => {
-  try {
-    const api = fetchUserInfo(userId, token);
-    await api.request();
-
-    const response = api.response.value;
-
-    if (response?.data) {
-      setUserInfo(response.data);
-      router.push("/medicos/inicio");
-    }
-  } catch (err) {
-    console.error("Error en getDoctorInfo:", err);
-  }
-};
-
-const getHospitalInfo = async (token: string) => {
-  try {
-    const api = fetchHospitalInfo(token);
-    await api.request();
-
-    const response = api.response.value;
-
-    if (response?.data) {
-      setUserInfo(response.data);
-      router.push("/medicos/inicio");
-    }
-  } catch (err) {
-    console.error("Error en getHospitalInfo:", err);
-  }
-};
-
-const getFinanceEntityInfo = async (decodedToken: DecodedToken) => {
-  setUserInfo(decodedToken);
-  router.push("/socio-financiero/inicio");
 };
 </script>
 

--- a/pages/pacientes/registro.vue
+++ b/pages/pacientes/registro.vue
@@ -53,16 +53,6 @@
         >
           <RegisterWithEmailForm />
         </section>
-
-        <!-- TODO: re-enable cédula registration when ready
-        <section
-          v-else-if="signupOption === 'idCard'"
-          class="signup-section signup-section--form-idcard"
-          aria-label="Formulario de registro con cédula"
-        >
-          <RegisterWithIdCardWizard @back-to-selector="handleBackToSelector" />
-        </section>
-        -->
       </div>
 
       <div
@@ -108,13 +98,13 @@
 <script lang="ts" setup>
 useSeoMeta({
   title: "Crear Cuenta — Vitalink",
-  description: "Regístrate como paciente y accede a todos los servicios de Vitalink.",
+  description:
+    "Regístrate como paciente y accede a todos los servicios de Vitalink.",
   ogTitle: "Crear Cuenta — Vitalink",
-  ogDescription: "Regístrate como paciente y accede a todos los servicios de Vitalink.",
+  ogDescription:
+    "Regístrate como paciente y accede a todos los servicios de Vitalink.",
 });
 
-// TODO: re-enable when cédula registration is restored
-// import RegisterWithIdCardWizard from "@/components/pacientes/registro/asistente-registro-cedula.vue";
 import RegisterWithEmailForm from "@/components/pacientes/registro/formulario-registro-correo.vue";
 import RegisterOptionSelector from "@/components/pacientes/registro/selector-opcion-registro.vue";
 import { nextTick, ref, watch } from "vue";
@@ -129,18 +119,6 @@ const continueSignup = () => {
   signupOption.value = option;
   statusMessage.value = `Mostrando formulario de registro por ${option === "idCard" ? "cédula" : "correo electrónico"}`;
 };
-
-// TODO: re-enable when option selector is restored
-// const handleBack = () => {
-//   signupOption.value = null;
-//   statusMessage.value = "Volviendo a opciones de registro";
-// };
-
-// TODO: re-enable when cédula registration is restored
-// const handleBackToSelector = () => {
-//   signupOption.value = null;
-//   statusMessage.value = "Volviendo a opciones de registro";
-// };
 
 watch(signupOption, async () => {
   await nextTick();


### PR DESCRIPTION
- Remove Google/Apple social login buttons from all login and registration pages
- Simplify doctor (legal representative) registration: drop auto-login, contract upload, and contract linking steps; show email confirmation screen on success
- Add isPendingApproval state on the email confirmation page for LEGAL_REPRESENTATIVE and FINANCE_ENTITY roles, showing a "pending Vitalink approval" message instead of redirecting to login
- Refactor patient login to use centralized ROLE_HOME_ROUTES and ROLES_REQUIRING_PROFILE constants from types/auth, removing per-role fetch functions
- Remove commented-out cédula registration code and dead TODO comments