### PR TITLE
Replace emoji password toggles with icon components, fix login redirects, and remove upfront token verification

### DIFF
--- a/components/pacientes/registro/formulario-registro-correo.vue
+++ b/components/pacientes/registro/formulario-registro-correo.vue
@@ -150,7 +150,10 @@
               "
               :aria-pressed="showPassword"
             >
-              <span aria-hidden="true">{{ showPassword ? "👁️" : "👁️‍🗨️" }}</span>
+              <span aria-hidden="true">
+                <AtomsIconsEyeOffIcon v-if="showPassword" />
+                <AtomsIconsEyeIcon v-else
+              /></span>
             </button>
           </div>
           <small id="password-hint" class="registration-hint">

--- a/pages/confirmation_register/[token].vue
+++ b/pages/confirmation_register/[token].vue
@@ -34,7 +34,7 @@
         comenzar a usar Vitalink.
       </p>
       <div class="success-message__actions">
-        <NuxtLink to="/pacientes/login" class="success-message__button">
+        <NuxtLink to="/auth/login" class="success-message__button">
           Ir a iniciar sesión
         </NuxtLink>
       </div>
@@ -52,7 +52,7 @@
         <NuxtLink to="/pacientes/registro" class="error-message__button">
           Volver al registro
         </NuxtLink>
-        <NuxtLink to="/pacientes/login" class="error-message__button-secondary">
+        <NuxtLink to="/auth/login" class="error-message__button-secondary">
           Ir a iniciar sesión
         </NuxtLink>
       </div>
@@ -69,8 +69,8 @@ useSeoMeta({
 });
 
 import { useAuth } from "@/composables/api";
-import { decodeJWT } from "@/utils/jwt";
 import { UserRole } from "@/types/auth";
+import { decodeJWT } from "@/utils/jwt";
 
 const route = useRoute();
 const { confirmationRegister } = useAuth();

--- a/pages/verify_forgot_password/[token].vue
+++ b/pages/verify_forgot_password/[token].vue
@@ -10,28 +10,7 @@
         </p>
       </div>
 
-      <div
-        v-if="tokenError"
-        class="token-error"
-        role="alert"
-        aria-labelledby="token-error-heading"
-      >
-        <div class="token-error__icon" aria-hidden="true">
-          <AtomsIconsCircleXIcon size="32" />
-        </div>
-        <h2 id="token-error-heading" class="token-error__title">
-          Enlace inválido o expirado
-        </h2>
-        <p class="token-error__description">
-          El enlace de recuperación es inválido o ha expirado. Por favor,
-          solicita uno nuevo.
-        </p>
-        <NuxtLink to="/auth/recuperar-contrasena" class="token-error__button">
-          Solicitar nuevo enlace
-        </NuxtLink>
-      </div>
-
-      <div v-else-if="!isSuccess" class="auth-form">
+      <div v-if="!isSuccess" class="auth-form">
         <form
           @submit.prevent="handleSubmit"
           novalidate
@@ -288,7 +267,7 @@ import { useAuth } from "@/composables/api";
 import { useToast } from "@/composables/useToast";
 
 const route = useRoute();
-const { resetPassword, verifyForgotPasswordToken } = useAuth();
+const { resetPassword } = useAuth();
 const toast = useToast();
 
 const password = ref<string>("");
@@ -297,8 +276,6 @@ const showPassword = ref<boolean>(false);
 const showConfirmPassword = ref<boolean>(false);
 const isLoading = ref<boolean>(false);
 const isSuccess = ref<boolean>(false);
-const isVerifyingToken = ref<boolean>(true);
-const tokenError = ref<boolean>(false);
 
 const touched = reactive({
   password: false,
@@ -333,28 +310,6 @@ const markAllTouched = () => {
   Object.keys(touched).forEach((key) => {
     touched[key as keyof typeof touched] = true;
   });
-};
-
-const verifyToken = async () => {
-  if (!token.value) {
-    isVerifyingToken.value = false;
-    tokenError.value = true;
-    toast.error(
-      "Token de recuperación no encontrado. Por favor, utiliza el enlace enviado a tu correo electrónico.",
-    );
-    return;
-  }
-
-  const { data, error } = await verifyForgotPasswordToken(token.value);
-
-  isVerifyingToken.value = false;
-
-  if (error || !data?.valid) {
-    tokenError.value = true;
-    toast.error(
-      "El enlace de recuperación es inválido o ha expirado. Por favor, solicita uno nuevo.",
-    );
-  }
 };
 
 const handleSubmit = async () => {
@@ -394,9 +349,6 @@ const handleSubmit = async () => {
   }, 3000);
 };
 
-onMounted(async () => {
-  await verifyToken();
-});
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
- Swap emoji eye characters for AtomsIconsEyeIcon/EyeOffIcon in the registration form
- Update confirmation_register page to redirect to /auth/login instead of /pacientes/login
- Remove the verifyForgotPasswordToken call on mount in the password reset page, showing the form directly and letting the reset API handle invalid tokens