### PR TITLE
Fix iOS Safari viewport, scroll-lock, and duplicate registration UX

### DIFF
--- a/components/atoms/modal-base.vue
+++ b/components/atoms/modal-base.vue
@@ -396,12 +396,15 @@ $modal-breakpoint: 48rem;
     overflow-y: auto;
     color: #374151;
     line-height: 1.6;
-    // Smooth momentum scrolling on iOS
     -webkit-overflow-scrolling: touch;
+    // Prevent scroll-chaining to the body on iOS when content reaches its boundary
+    overscroll-behavior: contain;
   }
 
   &__footer {
     padding: $modal-padding;
+    // Account for iOS home indicator on notched iPhones
+    padding-bottom: calc(#{$modal-padding} + env(safe-area-inset-bottom, 0px));
     display: flex;
     justify-content: flex-end;
     gap: 0.75rem;
@@ -431,43 +434,43 @@ $modal-breakpoint: 48rem;
       &--extra-small {
         width: 25rem;
         max-width: 90vw;
-        max-height: 90vh;
+        max-height: 90dvh;
       }
 
       &--small {
         width: 33.5rem;
         max-width: 90vw;
-        max-height: 90vh;
+        max-height: 90dvh;
       }
 
       &--medium {
         width: 39.75rem;
         max-width: 90vw;
-        max-height: 90vh;
+        max-height: 90dvh;
       }
 
       &--large {
         width: 44.875rem;
         max-width: 90vw;
-        max-height: 90vh;
+        max-height: 90dvh;
       }
 
       &--extra-large {
         width: 62.5rem;
         max-width: 90vw;
-        max-height: 90vh;
+        max-height: 90dvh;
       }
 
       &--fullscreen {
         width: 95vw;
         max-width: 95vw;
-        max-height: 95vh;
+        max-height: 95dvh;
         border-radius: $modal-border-radius;
       }
 
       &--custom {
         max-width: 90vw;
-        max-height: 90vh;
+        max-height: 90dvh;
       }
     }
 
@@ -481,6 +484,10 @@ $modal-breakpoint: 48rem;
 
     &__controls {
       gap: 0.5rem;
+    }
+
+    &__footer {
+      padding-bottom: $modal-padding;
     }
   }
 }

--- a/components/pacientes/registro/formulario-registro-correo.vue
+++ b/components/pacientes/registro/formulario-registro-correo.vue
@@ -544,7 +544,14 @@ const handleSubmit = async () => {
         message: error.value.message,
         data: error.value.data,
       });
-      toast.error("Error al registrar. Por favor intenta nuevamente.");
+      const errorCode = (error.value.data as any)?.data?.code;
+      if (errorCode === "ER_DUP_ENTRY") {
+        toast.error(
+          "El correo electrónico o número de documento ya está registrado.",
+        );
+      } else {
+        toast.error("Error al registrar. Por favor intenta nuevamente.");
+      }
       return;
     }
 

--- a/components/website/navbar.vue
+++ b/components/website/navbar.vue
@@ -408,7 +408,7 @@ onUnmounted(() => {
       top: 0;
       left: 0;
       width: 100%;
-      height: 100vh;
+      height: 100dvh;
       background: rgba(0, 0, 0, 0.6);
       z-index: 998;
       backdrop-filter: blur(2px);
@@ -429,7 +429,7 @@ onUnmounted(() => {
       top: 0;
       right: 0;
       width: min(100%, 25rem);
-      height: 100vh;
+      height: 100dvh;
       flex-direction: column;
       justify-content: space-between;
       background: $white;

--- a/components/website/reservar-modal.vue
+++ b/components/website/reservar-modal.vue
@@ -1027,10 +1027,9 @@ onUnmounted(() => {
 <style scoped>
 .modal-overlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  inset: 0;
+  // Respect notch/home-indicator on iOS
+  padding: env(safe-area-inset-top, 0px) env(safe-area-inset-right, 0px) env(safe-area-inset-bottom, 0px) env(safe-area-inset-left, 0px);
   background-color: rgba(0, 0, 0, 0.5);
   display: flex;
   justify-content: center;
@@ -1044,8 +1043,12 @@ onUnmounted(() => {
   border-radius: 8px;
   max-width: 900px;
   width: 100%;
-  height: 98vh;
+  // dvh accounts for the iOS Safari address bar (98vh does not)
+  max-height: 98dvh;
+  height: 100%;
   overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
 }
 
 .modal-content.confirmation {

--- a/composables/useScrollLock.ts
+++ b/composables/useScrollLock.ts
@@ -1,6 +1,10 @@
 const lockCount = ref(0);
+let savedScrollY = 0;
 let savedPaddingRight = "";
 let savedOverflow = "";
+let savedPosition = "";
+let savedTop = "";
+let savedWidth = "";
 
 function getScrollbarWidth(): number {
   if (typeof window === "undefined") return 0;
@@ -16,8 +20,12 @@ export function useScrollLock() {
     if (lockCount.value !== 1) return;
 
     const body = document.body;
+    savedScrollY = window.scrollY;
     savedOverflow = body.style.overflow;
     savedPaddingRight = body.style.paddingRight;
+    savedPosition = body.style.position;
+    savedTop = body.style.top;
+    savedWidth = body.style.width;
 
     const scrollbarWidth = getScrollbarWidth();
     if (scrollbarWidth > 0) {
@@ -25,6 +33,13 @@ export function useScrollLock() {
         parseInt(window.getComputedStyle(body).paddingRight, 10) || 0;
       body.style.paddingRight = `${computedPadding + scrollbarWidth}px`;
     }
+
+    // iOS Safari: position:fixed prevents momentum-scroll bleed-through.
+    // Saving scrollY and restoring it on unlock prevents the page from
+    // jumping to top when the fixed body is removed.
+    body.style.position = "fixed";
+    body.style.top = `-${savedScrollY}px`;
+    body.style.width = "100%";
     body.style.overflow = "hidden";
   };
 
@@ -35,18 +50,31 @@ export function useScrollLock() {
     if (lockCount.value > 0) return;
 
     const body = document.body;
-    if (savedOverflow === "") {
-      body.style.removeProperty("overflow");
-    } else {
-      body.style.overflow = savedOverflow;
-    }
-    if (savedPaddingRight === "") {
-      body.style.removeProperty("padding-right");
-    } else {
-      body.style.paddingRight = savedPaddingRight;
-    }
+
+    if (savedOverflow === "") body.style.removeProperty("overflow");
+    else body.style.overflow = savedOverflow;
+
+    if (savedPaddingRight === "") body.style.removeProperty("padding-right");
+    else body.style.paddingRight = savedPaddingRight;
+
+    if (savedPosition === "") body.style.removeProperty("position");
+    else body.style.position = savedPosition;
+
+    if (savedTop === "") body.style.removeProperty("top");
+    else body.style.top = savedTop;
+
+    if (savedWidth === "") body.style.removeProperty("width");
+    else body.style.width = savedWidth;
+
+    // Restore the scroll position that was saved before locking.
+    window.scrollTo(0, savedScrollY);
+
+    savedScrollY = 0;
     savedOverflow = "";
     savedPaddingRight = "";
+    savedPosition = "";
+    savedTop = "";
+    savedWidth = "";
   };
 
   return { lock, unlock, isLocked };


### PR DESCRIPTION
- Switch all vh units to dvh so modals and the navbar drawer account for the iOS Safari address bar correctly
- Add safe-area insets to modal footer and reservar-modal overlay to respect the notch and home indicator on notched iPhones
- Rewrite useScrollLock to use position:fixed + saved scrollY, preventing momentum-scroll bleed-through on iOS without losing the scroll position on unlock
- Add overscroll-behavior:contain to modal body and reservar-modal so scroll doesn't chain to the page body when content reaches its boundary
- Show a specific error message when patient registration fails due to a duplicate email or document number (ER_DUP_ENTRY)