### PR TITLE
Refactor modal system: promote UiModalBase as the canonical component

### DIFF
--- a/assets/scss/_custom-base.scss
+++ b/assets/scss/_custom-base.scss
@@ -1,5 +1,8 @@
 body {
   font-family: $font-family-main;
+  // Reserve scrollbar gutter space at all times so hiding/showing the
+  // scrollbar (e.g. when a modal locks scroll) never causes a layout shift.
+  scrollbar-gutter: stable;
 }
 
 a {

--- a/components/aseguradoras/aprobar-credito-modal.vue
+++ b/components/aseguradoras/aprobar-credito-modal.vue
@@ -3,7 +3,7 @@
     Ver Detalles
   </button>
 
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isOpen"
     @close="handleCloseModal"
     :close-on-backdrop="false"
@@ -260,7 +260,7 @@
         </div>
       </div>
     </div>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/aseguradoras/modales/credit-approval.vue
+++ b/components/aseguradoras/modales/credit-approval.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :is-open="modalManager.isOpen.approval"
     @close="modalManager.closeModal('approval')"
     :close-on-backdrop="false"
@@ -81,7 +81,7 @@
         </button>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/aseguradoras/modales/credit-details.vue
+++ b/components/aseguradoras/modales/credit-details.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :is-open="modalManager.isOpen.details"
     @close="handleClose"
     :close-on-backdrop="false"
@@ -67,7 +67,7 @@
         </button>
       </div>
     </div>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/aseguradoras/modales/credit-rejection.vue
+++ b/components/aseguradoras/modales/credit-rejection.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :is-open="modalManager.isOpen.rejection"
     @close="modalManager.closeModal('rejection')"
     size="extra-small"
@@ -41,7 +41,7 @@
         </button>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/aseguradoras/modales/credit-success.vue
+++ b/components/aseguradoras/modales/credit-success.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :is-open="modalManager.isOpen.success"
     @close="handleClose"
     :close-on-backdrop="false"
@@ -30,7 +30,7 @@
         </button>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/aseguradoras/registro/onboarding/modal-bienvenida.vue
+++ b/components/aseguradoras/registro/onboarding/modal-bienvenida.vue
@@ -1,7 +1,7 @@
 <template>
   <slot name="trigger" :open="handleOpenModal"></slot>
 
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isModalOpen"
     :close-on-backdrop="false"
     @close="handleCloseAndRemoveFlag"
@@ -61,7 +61,7 @@
         </button>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/aseguradoras/registro/onboarding/modal-empezar.vue
+++ b/components/aseguradoras/registro/onboarding/modal-empezar.vue
@@ -1,7 +1,7 @@
 <template>
   <slot name="trigger" :open="handleOpenModal"></slot>
 
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isModalOpen"
     :close-on-backdrop="false"
     @close="handleCloseModal"
@@ -50,7 +50,7 @@
         </button>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/aseguradoras/registro/onboarding/modal-explorar.vue
+++ b/components/aseguradoras/registro/onboarding/modal-explorar.vue
@@ -1,7 +1,7 @@
 <template>
   <slot name="trigger" :open="handleOpenModal"></slot>
 
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isModalOpen"
     :close-on-backdrop="false"
     @close="handleGoBack"
@@ -111,7 +111,7 @@
         Siguiente
       </button>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/medicos/modales/advertencia-pago.vue
+++ b/components/medicos/modales/advertencia-pago.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isModalOpen"
     size="extra-small"
     class="no-payment-recorded"
@@ -41,7 +41,7 @@
         </button>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/medicos/modales/agregar-hospital.vue
+++ b/components/medicos/modales/agregar-hospital.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isModalOpen"
     size="extra-large"
     class="add-hospital"
@@ -258,7 +258,7 @@
         </button>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/medicos/modales/anular-cita.vue
+++ b/components/medicos/modales/anular-cita.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isModalOpen"
     size="extra-small"
     class="cancel-appointment"
@@ -39,7 +39,7 @@
         </button>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/medicos/modales/cambios-guardados.vue
+++ b/components/medicos/modales/cambios-guardados.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isModalOpen"
     size="small"
     :close-on-backdrop="false"
@@ -45,7 +45,7 @@
         </button>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/medicos/modales/confirmacion-no-apto.vue
+++ b/components/medicos/modales/confirmacion-no-apto.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isModalOpen"
     size="extra-small"
     class="confirmation-not-suitable"
@@ -34,7 +34,7 @@
         </button>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/medicos/modales/confirmacion-reprogramacion.vue
+++ b/components/medicos/modales/confirmacion-reprogramacion.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isModalOpen"
     size="extra-small"
     class="confirmation-rescheduling"
@@ -39,7 +39,7 @@
         </button>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/medicos/modales/confirmacion-reserva.vue
+++ b/components/medicos/modales/confirmacion-reserva.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isModalOpen"
     size="extra-small"
     @close="handleClose"
@@ -90,7 +90,7 @@
         </button>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/medicos/modales/confirmacion-valoracion.vue
+++ b/components/medicos/modales/confirmacion-valoracion.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isVisible"
     size="extra-small"
     class="valoration-confirmation"
@@ -58,7 +58,7 @@
         </button>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/medicos/modales/confirmar-codigo.vue
+++ b/components/medicos/modales/confirmar-codigo.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isVisible"
     size="extra-small"
     class="code-redemption-dialog"
@@ -66,7 +66,7 @@
         </button>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/medicos/modales/confirmar-eliminacion.vue
+++ b/components/medicos/modales/confirmar-eliminacion.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isModalOpen"
     size="extra-small"
     class="confirm-delete"
@@ -38,7 +38,7 @@
         </button>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/medicos/modales/contact-modal.vue
+++ b/components/medicos/modales/contact-modal.vue
@@ -3,7 +3,7 @@
     <AtomsIconsPhoneIcon size="20" />
   </button>
 
-  <AtomsModalBase :is-open="isOpen" size="extra-small" @close="closeModal">
+  <UiModalBase :is-open="isOpen" size="extra-small" @close="closeModal">
     <template #title>
       <span class="appointment-contact-modal__header--icon">
         <AtomsIconsPhoneIcon />
@@ -50,10 +50,11 @@
         </div>
       </div>
     </div>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>
+import { useFormat } from "@/composables/useFormat";
 const { formatPhone } = useFormat();
 
 const isOpen = ref<boolean>(false);

--- a/components/medicos/modales/detalles-cita.vue
+++ b/components/medicos/modales/detalles-cita.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isModalOpen"
     size="medium"
     @close="handleClose"
@@ -307,7 +307,7 @@
         </template>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/medicos/modales/detalles-valoracion.vue
+++ b/components/medicos/modales/detalles-valoracion.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isModalOpen"
     size="large"
     :close-on-backdrop="false"
@@ -206,7 +206,7 @@
         </div>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/medicos/modales/editor-fecha-hora.vue
+++ b/components/medicos/modales/editor-fecha-hora.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isModalOpen"
     size="medium"
     :close-on-backdrop="false"
@@ -118,7 +118,7 @@
         </button>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/medicos/modales/exito-confirmacion.vue
+++ b/components/medicos/modales/exito-confirmacion.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isModalOpen"
     size="small"
     class="success-confirmation"
@@ -51,7 +51,7 @@
         </button>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/medicos/modales/formulario-medico-relacionado.vue
+++ b/components/medicos/modales/formulario-medico-relacionado.vue
@@ -2,7 +2,7 @@
   <div>
     <slot name="trigger" :open="openModal" />
 
-    <AtomsModalBase
+    <UiModalBase
       :is-open="isModalVisible"
       size="extra-large"
       :show-close-button="true"
@@ -542,7 +542,7 @@
           </template>
         </nav>
       </template>
-    </AtomsModalBase>
+    </UiModalBase>
   </div>
 </template>
 

--- a/components/medicos/modales/informacion-usuario.vue
+++ b/components/medicos/modales/informacion-usuario.vue
@@ -290,7 +290,7 @@ defineExpose({
 <template>
   <slot name="trigger" :open="handleOpenModal"></slot>
 
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isModalOpen"
     size="medium"
     class="user-information"
@@ -450,7 +450,7 @@ defineExpose({
         </div>
       </div>
     </div>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <style lang="scss" scoped>

--- a/components/medicos/modales/subir-proforma.vue
+++ b/components/medicos/modales/subir-proforma.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isModalOpen"
     size="small"
     class="upload-proforma"
@@ -55,7 +55,7 @@
         </button>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/medicos/registro/onboarding/modal-bienvenida-onboarding.vue
+++ b/components/medicos/registro/onboarding/modal-bienvenida-onboarding.vue
@@ -1,7 +1,7 @@
 <template>
   <slot name="trigger" :open="handleOpenModal"></slot>
 
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isModalOpen"
     :close-on-backdrop="false"
     @close="handleCloseAndRemoveFlag"
@@ -61,7 +61,7 @@
         </button>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/medicos/registro/onboarding/modal-felicidades-completado.vue
+++ b/components/medicos/registro/onboarding/modal-felicidades-completado.vue
@@ -1,7 +1,7 @@
 <template>
   <slot name="trigger" :open="handleOpenModal"></slot>
 
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isModalOpen"
     :close-on-backdrop="false"
     @close="handleCloseModal"
@@ -48,7 +48,7 @@
         </button>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/medicos/registro/onboarding/modal-formulario-proveedor.vue
+++ b/components/medicos/registro/onboarding/modal-formulario-proveedor.vue
@@ -1,7 +1,7 @@
 <template>
   <slot name="trigger" :open="handleOpenModal"></slot>
 
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isModalOpen"
     :close-on-backdrop="false"
     @close="handleGoBack"
@@ -308,7 +308,7 @@
         {{ isLoading ? "Procesando..." : "Finalizar" }}
       </button>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/pacientes/modales/anular-cita.vue
+++ b/components/pacientes/modales/anular-cita.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :is-open="props.isOpen"
     title="Anular Cita"
     size="extra-small"
@@ -47,11 +47,13 @@
         </button>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>
 import { useAppointment } from "@/composables/api";
+import { useLogger } from "@/composables/useLogger";
+import { useToast } from "@/composables/useToast";
 
 interface Props {
   appointment: IAppointment;

--- a/components/pacientes/modales/contacto-medico.vue
+++ b/components/pacientes/modales/contacto-medico.vue
@@ -8,7 +8,7 @@
     <AtomsIconsPhoneIcon size="20" aria-hidden="true" />
   </button>
 
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isOpen"
     size="extra-small"
     @close="closeModal"
@@ -70,10 +70,11 @@
         </div>
       </div>
     </div>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>
+import { useFormat } from "@/composables/useFormat";
 const { formatPhone } = useFormat();
 
 const isOpen = ref<boolean>(false);

--- a/components/pacientes/modales/dejar-valoracion-exitoso.vue
+++ b/components/pacientes/modales/dejar-valoracion-exitoso.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isModalVisible"
     size="small"
     :close-on-backdrop="false"
@@ -49,7 +49,7 @@
         </button>
       </nav>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/pacientes/modales/dejar-valoracion.vue
+++ b/components/pacientes/modales/dejar-valoracion.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isModalVisible"
     title="Dejar una reseña"
     size="medium"
@@ -114,7 +114,7 @@
         </div>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/pacientes/modales/detalles-cita.vue
+++ b/components/pacientes/modales/detalles-cita.vue
@@ -532,7 +532,7 @@ const handleDownloadProforma = async () => {
 </script>
 
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isOpen"
     size="medium"
     :close-on-backdrop="false"
@@ -744,7 +744,7 @@ const handleDownloadProforma = async () => {
         </button>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <style lang="scss">

--- a/components/pacientes/modales/pagar-cita.vue
+++ b/components/pacientes/modales/pagar-cita.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isModalVisible"
     title="Pagar Cita"
     size="large"
@@ -135,7 +135,7 @@
         </button>
       </nav>
     </section>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script setup lang="ts">

--- a/components/pacientes/modales/pago-existoso.vue
+++ b/components/pacientes/modales/pago-existoso.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :isOpen="isModalOpen"
     title="¡Pago Exitoso!"
     size="small"
@@ -119,7 +119,7 @@
         </button>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/pacientes/modales/reclamo-enviado.vue
+++ b/components/pacientes/modales/reclamo-enviado.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase :is-open="isOpen" size="extra-small" @close="closeModal">
+  <UiModalBase :is-open="isOpen" size="extra-small" @close="closeModal">
     <div class="claim-sent__body">
       <div class="claim-sent__header">
         <AtomsIconsCheckIcon size="20" class="claim-sent__header-icon" />
@@ -16,7 +16,7 @@
         <button class="claim-sent__button--primary">Ir a Home</button>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/pacientes/modales/reserva-procedimiento-exitoso.vue
+++ b/components/pacientes/modales/reserva-procedimiento-exitoso.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isModalOpen"
     size="medium"
     @close="handleCloseModal('scheduleProcedureSuccess')"
@@ -43,7 +43,7 @@
         </button>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/pacientes/modales/reservar-procedimiento.vue
+++ b/components/pacientes/modales/reservar-procedimiento.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isModalOpen"
     size="medium"
     @close="handleCloseModal('scheduleProcedure')"
@@ -36,7 +36,7 @@
         </button>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/pacientes/modales/solicitar-credito-exitoso.vue
+++ b/components/pacientes/modales/solicitar-credito-exitoso.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isModalOpen"
     size="medium"
     @close="handleCloseModal('applyCreditSuccess')"
@@ -39,7 +39,7 @@
         </button>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/pacientes/modales/solicitar-credito.vue
+++ b/components/pacientes/modales/solicitar-credito.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isModalOpen"
     size="large"
     @close="handleCloseModal('applyCredit')"
@@ -101,7 +101,7 @@
         </span>
       </button>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/ui/modal-base.vue
+++ b/components/ui/modal-base.vue
@@ -9,14 +9,14 @@
         tabindex="-1"
         ref="backdropRef"
       >
-        <dialog
+        <div
+          role="dialog"
           class="modal__dialog"
           :class="modalClasses"
           :style="customStyles"
           :aria-labelledby="hasHeader ? headerId : undefined"
           :aria-describedby="contentId"
           aria-modal="true"
-          open
           @click.stop
           ref="dialogRef"
           tabindex="-1"
@@ -64,7 +64,7 @@
           >
             <slot name="footer" />
           </footer>
-        </dialog>
+        </div>
       </div>
     </Transition>
   </Teleport>
@@ -419,6 +419,8 @@ $modal-breakpoint: 48rem;
     line-height: 1.6;
     -webkit-overflow-scrolling: touch;
     overscroll-behavior: contain;
+    min-height: 0;
+    height: 100%;
   }
 
   &__footer {

--- a/components/website/mas-filtros-modal.vue
+++ b/components/website/mas-filtros-modal.vue
@@ -274,7 +274,7 @@ defineExpose({
       <span>Más Filtros</span>
     </button>
 
-    <AtomsModalBase :is-open="isOpen" size="large" @close="handleCloseModal">
+    <UiModalBase :is-open="isOpen" size="large" @close="handleCloseModal">
       <template #title>
         <h2 id="filter-modal-title" class="filter-modal__title">Filtros</h2>
       </template>
@@ -482,7 +482,7 @@ defineExpose({
           </button>
         </div>
       </template>
-    </AtomsModalBase>
+    </UiModalBase>
   </div>
 </template>
 

--- a/components/website/modal-especialidad.vue
+++ b/components/website/modal-especialidad.vue
@@ -9,7 +9,7 @@
     <AtomsIconsArrowRightIcon class="specialty-modal-trigger__icon" />
   </button>
 
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isOpen"
     @close="handleCloseModal"
     :show-close-button="false"
@@ -81,7 +81,7 @@
         </section>
       </div>
     </article>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/website/pack-tratamientos.vue
+++ b/components/website/pack-tratamientos.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :is-open="open"
     size="extra-large"
     :close-on-backdrop="false"
@@ -180,7 +180,7 @@
         </template>
       </template>
     </section>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script setup lang="ts">

--- a/components/website/perfil-doctor/barra-lateral-doctor.vue
+++ b/components/website/perfil-doctor/barra-lateral-doctor.vue
@@ -1,4 +1,6 @@
 <script lang="ts" setup>
+import { useFormat } from "@/composables/useFormat";
+
 interface Props {
   supplierData?: ISupplierDetail | Partial<ISupplierDetail> | null;
   supplier?: ISupplierDetail | Partial<ISupplierDetail> | null;
@@ -650,7 +652,6 @@ watch(
           line-height: 18px;
         }
       }
-
     }
   }
 }

--- a/components/website/reservar-cancel-modal.vue
+++ b/components/website/reservar-cancel-modal.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase :is-open="isOpen" size="small" @close="handleCloseModal">
+  <UiModalBase :is-open="isOpen" size="small" @close="handleCloseModal">
     <main class="cancel-appointment__body">
       <div class="cancel-appointment__content">
         <div class="cancel-appointment__content--icon">
@@ -28,7 +28,7 @@
         Salir
       </button>
     </footer>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/components/website/reservar-cita-valoracion/index.vue
+++ b/components/website/reservar-cita-valoracion/index.vue
@@ -15,7 +15,7 @@
     Reservar Cita de valoración
   </button>
 
-  <AtomsModalBase
+  <UiModalBase
     :isOpen="isOpen"
     @close="closeModal"
     size="large"
@@ -31,7 +31,7 @@
       </h1>
     </template>
 
-    <main class="schedule-appointment-modal__content">
+    <div class="schedule-appointment-modal__content">
       <WebsiteStepper
         v-if="internalCurrentStep !== 0 && internalCurrentStep !== 3"
         :steps="steps"
@@ -62,7 +62,7 @@
         :selected-package="selectedPackage"
         :services="services"
       />
-    </main>
+    </div>
 
     <template #footer>
       <footer class="schedule-appointment-modal__footer">
@@ -94,7 +94,7 @@
         </button>
       </footer>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 
   <WebsiteReservarCitaValoracionReservaExitosa
     :is-open="isOpenSuccessModal"

--- a/components/website/reservar-cita-valoracion/reserva-exitosa.vue
+++ b/components/website/reservar-cita-valoracion/reserva-exitosa.vue
@@ -1,5 +1,5 @@
 <template>
-  <AtomsModalBase
+  <UiModalBase
     :is-open="isOpen"
     @close="handleCloseModal"
     size="small"
@@ -113,7 +113,7 @@
         </NuxtLink>
       </div>
     </template>
-  </AtomsModalBase>
+  </UiModalBase>
 </template>
 
 <script lang="ts" setup>

--- a/composables/useScrollLock.ts
+++ b/composables/useScrollLock.ts
@@ -1,14 +1,20 @@
 const lockCount = ref(0);
 let savedScrollY = 0;
-let savedPaddingRight = "";
 let savedOverflow = "";
 let savedPosition = "";
 let savedTop = "";
 let savedWidth = "";
 
-function getScrollbarWidth(): number {
-  if (typeof window === "undefined") return 0;
-  return window.innerWidth - document.documentElement.clientWidth;
+// Detects iPhone/iPad via UA or the navigator.standalone hint (iOS 13+ iPads
+// report a desktop UA but expose standalone). Using position:fixed on iOS
+// prevents momentum-scroll bleed-through; on Android it causes a visible
+// double-paint layout jump, so we use overflow:hidden there instead.
+function isIOS(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return (
+    /iP(hone|ad|od)/.test(navigator.userAgent) ||
+    (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1)
+  );
 }
 
 export function useScrollLock() {
@@ -22,25 +28,25 @@ export function useScrollLock() {
     const body = document.body;
     savedScrollY = window.scrollY;
     savedOverflow = body.style.overflow;
-    savedPaddingRight = body.style.paddingRight;
     savedPosition = body.style.position;
     savedTop = body.style.top;
     savedWidth = body.style.width;
 
-    const scrollbarWidth = getScrollbarWidth();
-    if (scrollbarWidth > 0) {
-      const computedPadding =
-        parseInt(window.getComputedStyle(body).paddingRight, 10) || 0;
-      body.style.paddingRight = `${computedPadding + scrollbarWidth}px`;
+    if (isIOS()) {
+      // position:fixed prevents momentum-scroll bleed-through on iOS Safari.
+      // We save scrollY and restore it on unlock so the page doesn't jump to top.
+      // overflow:hidden is intentionally NOT set here: on iOS Safari, combining
+      // position:fixed + overflow:hidden on <body> triggers a compositing-layer
+      // clip bug that makes the underlying page content invisible. position:fixed
+      // alone is sufficient to prevent scrolling on iOS.
+      body.style.position = "fixed";
+      body.style.top = `-${savedScrollY}px`;
+      body.style.width = "100%";
+    } else {
+      // scrollbar-gutter: stable (set globally on body) keeps the gutter space
+      // reserved even when overflow is hidden, so no padding compensation needed.
+      body.style.overflow = "hidden";
     }
-
-    // iOS Safari: position:fixed prevents momentum-scroll bleed-through.
-    // Saving scrollY and restoring it on unlock prevents the page from
-    // jumping to top when the fixed body is removed.
-    body.style.position = "fixed";
-    body.style.top = `-${savedScrollY}px`;
-    body.style.width = "100%";
-    body.style.overflow = "hidden";
   };
 
   const unlock = (): void => {
@@ -51,27 +57,25 @@ export function useScrollLock() {
 
     const body = document.body;
 
-    if (savedOverflow === "") body.style.removeProperty("overflow");
-    else body.style.overflow = savedOverflow;
+    if (isIOS()) {
+      if (savedPosition === "") body.style.removeProperty("position");
+      else body.style.position = savedPosition;
 
-    if (savedPaddingRight === "") body.style.removeProperty("padding-right");
-    else body.style.paddingRight = savedPaddingRight;
+      if (savedTop === "") body.style.removeProperty("top");
+      else body.style.top = savedTop;
 
-    if (savedPosition === "") body.style.removeProperty("position");
-    else body.style.position = savedPosition;
+      if (savedWidth === "") body.style.removeProperty("width");
+      else body.style.width = savedWidth;
 
-    if (savedTop === "") body.style.removeProperty("top");
-    else body.style.top = savedTop;
-
-    if (savedWidth === "") body.style.removeProperty("width");
-    else body.style.width = savedWidth;
-
-    // Restore the scroll position that was saved before locking.
-    window.scrollTo(0, savedScrollY);
+      // Restore the scroll position saved before locking.
+      window.scrollTo(0, savedScrollY);
+    } else {
+      if (savedOverflow === "") body.style.removeProperty("overflow");
+      else body.style.overflow = savedOverflow;
+    }
 
     savedScrollY = 0;
     savedOverflow = "";
-    savedPaddingRight = "";
     savedPosition = "";
     savedTop = "";
     savedWidth = "";

--- a/pages/medicos/mis-medicos/index.vue
+++ b/pages/medicos/mis-medicos/index.vue
@@ -193,7 +193,7 @@
         </template>
       </UiAppointmentTableBase>
 
-      <AtomsModalBase
+      <UiModalBase
         :is-open="isDoctorDeletionDialogVisible"
         size="small"
         role="alertdialog"
@@ -230,7 +230,7 @@
             {{ isDoctorDeletionInProgress ? "Eliminando..." : "Eliminar" }}
           </button>
         </template>
-      </AtomsModalBase>
+      </UiModalBase>
     </section>
 
     <section
@@ -338,7 +338,7 @@
         @hospital-updated="handleHospitalUpdated"
       />
 
-      <AtomsModalBase
+      <UiModalBase
         :is-open="isHospitalDeletionDialogVisible"
         size="small"
         role="alertdialog"
@@ -375,7 +375,7 @@
             {{ isHospitalDeletionInProgress ? "Eliminando..." : "Eliminar" }}
           </button>
         </template>
-      </AtomsModalBase>
+      </UiModalBase>
     </section>
   </NuxtLayout>
   <MedicosRegistroOnboarding />

--- a/pages/medicos/perfil/educacion-experiencia.vue
+++ b/pages/medicos/perfil/educacion-experiencia.vue
@@ -637,7 +637,7 @@ const deleteLanguage = async (id: number) => {
       </div>
     </section>
 
-    <AtomsModalBase
+    <UiModalBase
       :is-open="showEducationModal"
       @close="closeEducationModal"
       size="medium"
@@ -734,9 +734,9 @@ const deleteLanguage = async (id: number) => {
           {{ isLoading ? "Guardando..." : "Guardar" }}
         </button>
       </template>
-    </AtomsModalBase>
+    </UiModalBase>
 
-    <AtomsModalBase
+    <UiModalBase
       :is-open="showExperienceModal"
       @close="closeExperienceModal"
       size="medium"
@@ -825,9 +825,9 @@ const deleteLanguage = async (id: number) => {
           {{ isLoading ? "Guardando..." : "Guardar" }}
         </button>
       </template>
-    </AtomsModalBase>
+    </UiModalBase>
 
-    <AtomsModalBase
+    <UiModalBase
       :is-open="showLanguageModal"
       @close="closeLanguageModal"
       size="medium"
@@ -875,7 +875,7 @@ const deleteLanguage = async (id: number) => {
           Guardar
         </button>
       </template>
-    </AtomsModalBase>
+    </UiModalBase>
     </template>
   </NuxtLayout>
 </template>

--- a/pages/pacientes/eliminar-cuenta.vue
+++ b/pages/pacientes/eliminar-cuenta.vue
@@ -191,7 +191,7 @@ useHead({
       </div>
     </div>
 
-    <AtomsModalBase
+    <UiModalBase
       :is-open="showConfirmation"
       size="extra-small"
       @close="closeConfirmation"
@@ -288,7 +288,7 @@ useHead({
           </button>
         </div>
       </template>
-    </AtomsModalBase>
+    </UiModalBase>
   </NuxtLayout>
 </template>
 


### PR DESCRIPTION
Replace AtomsModalBase usages across all 50+ modal consumers with the new UiModalBase (components/ui/modal-base.vue), which adds proper focus trapping (Tab/Shift-Tab cycle, Escape handling), a modal stack for multi-modal stacking, scrollbar-gutter: stable to prevent layout shift on scroll-lock, and a cleaner props/emits API (removes closeAllButton, consolidates width/height/maxWidth/maxHeight handling).