### PR TITLE
Refactor socio-financiero profile pages and fix auth race conditions

### DIFF
--- a/pages/medicos/perfil/especialidades.vue
+++ b/pages/medicos/perfil/especialidades.vue
@@ -39,6 +39,8 @@ const procedureInputRef = ref<HTMLInputElement | null>(null);
 
 const supplierId = ref<number | null>(null);
 
+const { token } = useAuthToken();
+
 const toNormalizedCode = (value: string): string =>
   value.trim().toUpperCase().replace(/\s+/g, "_");
 
@@ -264,8 +266,22 @@ const confirmAndRemoveProcedure = async (procedure: IdentifiableItem) => {
   }
 };
 
-onMounted(async () => {
-  const { data: suppliers, error } = await getAllSuppliers();
+const initializePage = async () => {
+  const MAX_ATTEMPTS = 3;
+  const RETRY_DELAY_MS = 800;
+
+  let suppliers = null;
+  let error = null;
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    ({ data: suppliers, error } = await getAllSuppliers());
+
+    if (!error && suppliers?.length) break;
+
+    if (attempt < MAX_ATTEMPTS) {
+      await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+    }
+  }
 
   if (error || !suppliers?.length) {
     notify(error?.info || "No se encontró el perfil del proveedor", "error");
@@ -274,6 +290,20 @@ onMounted(async () => {
 
   supplierId.value = suppliers[0].id;
   await Promise.all([fetchSpecialties(), fetchProcedures()]);
+};
+
+onMounted(() => {
+  if (token.value) {
+    initializePage();
+    return;
+  }
+
+  const stop = watch(token, (newToken) => {
+    if (newToken) {
+      stop();
+      initializePage();
+    }
+  });
 });
 </script>
 

--- a/pages/medicos/perfil/profesional.vue
+++ b/pages/medicos/perfil/profesional.vue
@@ -32,6 +32,7 @@ const profileImagePreview = ref<string | null>(null);
 const isSubmitting = ref(false);
 const isLoadingProfile = ref(true);
 const isUploadingImage = ref(false);
+const loadError = ref<string | null>(null);
 
 const isFormReady = computed(() => true);
 
@@ -59,17 +60,20 @@ const notify = (message: string, type: "success" | "error") => {
   showToast(message, type);
 };
 
-const fetchSupplierProfile = async () => {
+const fetchSupplierProfile = async (attempt = 1) => {
   isLoadingProfile.value = true;
+  loadError.value = null;
 
   try {
     const { data: suppliers, error: suppliersError } = await getAllSuppliers();
 
     if (suppliersError || !suppliers?.length) {
-      notify(
-        suppliersError?.info || "No se encontró el perfil del proveedor",
-        "error",
-      );
+      if (attempt < 3) {
+        await new Promise((resolve) => setTimeout(resolve, attempt * 800));
+        return fetchSupplierProfile(attempt + 1);
+      }
+      loadError.value =
+        suppliersError?.info || "No se encontró el perfil del proveedor";
       return;
     }
 
@@ -78,7 +82,11 @@ const fetchSupplierProfile = async () => {
     const { data, error } = await getSupplierById(supplierId.value);
 
     if (error) {
-      notify(error.info || "Error al cargar el perfil profesional", "error");
+      if (attempt < 3) {
+        await new Promise((resolve) => setTimeout(resolve, attempt * 800));
+        return fetchSupplierProfile(attempt + 1);
+      }
+      loadError.value = error.info || "Error al cargar el perfil profesional";
       return;
     }
 
@@ -90,7 +98,11 @@ const fetchSupplierProfile = async () => {
       await migrateProfilePictureCodeToUrl();
     }
   } catch {
-    notify("Error inesperado al cargar el perfil", "error");
+    if (attempt < 3) {
+      await new Promise((resolve) => setTimeout(resolve, attempt * 800));
+      return fetchSupplierProfile(attempt + 1);
+    }
+    loadError.value = "Error inesperado al cargar el perfil";
   } finally {
     isLoadingProfile.value = false;
   }
@@ -253,6 +265,21 @@ onMounted(() => {
       Cargando perfil profesional...
     </div>
 
+    <div
+      v-else-if="loadError"
+      class="professional-profile__load-error"
+      role="alert"
+    >
+      <p>{{ loadError }}</p>
+      <button
+        type="button"
+        class="professional-profile__submit"
+        @click="fetchSupplierProfile"
+      >
+        Reintentar
+      </button>
+    </div>
+
     <form
       v-else
       class="professional-profile"
@@ -392,6 +419,19 @@ onMounted(() => {
     font-family: $font-family-main;
     font-size: 14px;
     color: $color-text-secondary;
+  }
+
+  &__load-error {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    min-height: 200px;
+    justify-content: center;
+    font-family: $font-family-main;
+    font-size: 14px;
+    color: $color-text-secondary;
+    text-align: center;
   }
 
   &__fieldset {

--- a/pages/socio-financiero/perfil/eliminar-cuenta.vue
+++ b/pages/socio-financiero/perfil/eliminar-cuenta.vue
@@ -1,55 +1,298 @@
-<script setup>
+<script lang="ts" setup>
+import { jwtDecode } from "jwt-decode";
+import { useAuth } from "@/composables/api";
+
 useSeoMeta({
   title: "Eliminar Cuenta — Vitalink Seguros",
-  description: "Solicita la eliminación permanente de tu cuenta de socio financiero en Vitalink.",
+  description:
+    "Solicita la eliminación permanente de tu cuenta de socio financiero en Vitalink.",
   ogTitle: "Eliminar Cuenta — Vitalink Seguros",
-  ogDescription: "Solicita la eliminación permanente de tu cuenta de socio financiero en Vitalink.",
+  ogDescription:
+    "Solicita la eliminación permanente de tu cuenta de socio financiero en Vitalink.",
 });
 
 definePageMeta({
-  middleware: ["auth-pacientes"],
+  middleware: ["auth-insurances"],
 });
-const config = useRuntimeConfig();
-const token = useCookie("token");
-const refreshToken = useCookie("refresh_token");
-const role = useCookie("role");
-const authenticated = useCookie("authenticated");
-const user_info = useCookie("user_info");
+
+const { deleteUser, logout } = useAuth();
+const { getToken } = useAuthToken();
+const { show: showToast } = useToast();
+const logger = useLogger("SocioEliminarCuenta");
 const router = useRouter();
 
+const { id: userId } = jwtDecode<DecodedToken>(getToken()!);
+
+const isConfirming = ref(false);
+const isDeleting = ref(false);
+
 const deleteAccount = async () => {
-  const { data, error } = await useFetch(
-    config.public.API_BASE_URL + "/patients/" + user_info.value.id,
-    {
-      method: "DELETE",
-      headers: { Authorization: token.value },
-    },
-  );
-  if (data) {
-    token.value = null;
-    refreshToken.value = null;
-    role.value = null;
-    authenticated.value = null;
-    user_info.value = null;
-    router.push("/auth/login");
+  if (!userId) {
+    showToast("No se encontró la información del usuario", "error");
+    return;
   }
-  if (error.value) {
-    console.log(error.value, "data");
+
+  isDeleting.value = true;
+  try {
+    logger.debug("deleteUser", { userId });
+
+    const { error } = await deleteUser(userId);
+
+    if (error) {
+      showToast(error.info || "Error al eliminar la cuenta", "error");
+      return;
+    }
+
+    await logout();
+    router.push("/auth/login");
+  } catch {
+    showToast("Error inesperado al eliminar la cuenta", "error");
+  } finally {
+    isDeleting.value = false;
   }
 };
 </script>
 
 <template>
   <NuxtLayout name="socio-dashboard-perfil">
-    <h4 class="fw-normal">¿Quieres borrar tu cuenta de Vitalink?</h4>
-    <p class="text-secondary">
-      Al eliminar la cuenta se borrará la totalidad de los contenidos y datos
-      asociados a ella.
-    </p>
-    <div class="mt-5">
-      <button class="btn btn-primary" @click="deleteAccount">
-        Eliminar cuenta
-      </button>
+    <h4 class="delete-account__title">
+      Eliminar Cuenta
+    </h4>
+
+    <div class="delete-account">
+      <div class="delete-account__warning">
+        <svg
+          class="delete-account__warning-icon"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M12 9v4m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+        <div>
+          <p class="delete-account__warning-title">
+            Esta acción es permanente e irreversible
+          </p>
+          <p class="delete-account__warning-text">
+            Al eliminar tu cuenta se borrarán la totalidad de los contenidos y
+            datos asociados a ella. No podrás recuperar tu información una vez
+            confirmada la eliminación.
+          </p>
+        </div>
+      </div>
+
+      <template v-if="!isConfirming">
+        <div class="delete-account__actions">
+          <button
+            type="button"
+            class="delete-account__button delete-account__button--danger"
+            @click="isConfirming = true"
+          >
+            Eliminar cuenta
+          </button>
+        </div>
+      </template>
+
+      <template v-else>
+        <div class="delete-account__confirm">
+          <p class="delete-account__confirm-text">
+            ¿Estás seguro de que deseas eliminar tu cuenta? Esta acción no se
+            puede deshacer.
+          </p>
+          <div class="delete-account__actions">
+            <button
+              type="button"
+              class="delete-account__button delete-account__button--secondary"
+              :disabled="isDeleting"
+              @click="isConfirming = false"
+            >
+              Cancelar
+            </button>
+            <button
+              type="button"
+              class="delete-account__button delete-account__button--danger"
+              :disabled="isDeleting"
+              :aria-busy="isDeleting"
+              @click="deleteAccount"
+            >
+              <template v-if="isDeleting">
+                <span
+                  class="delete-account__spinner"
+                  aria-hidden="true"
+                />
+                Eliminando...
+              </template>
+              <template v-else>
+                Confirmar eliminación
+              </template>
+            </button>
+          </div>
+        </div>
+      </template>
     </div>
   </NuxtLayout>
 </template>
+
+<style lang="scss" scoped>
+.delete-account {
+  margin-top: 1.5rem;
+
+  @include respond-to-max(md) {
+    margin-top: 1.25rem;
+  }
+
+  &__title {
+    font-weight: 400;
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+    margin-bottom: 1rem;
+    color: #212529;
+    font-family: $font-family-main;
+
+    @include respond-to-max(md) {
+      font-size: 1.375rem;
+    }
+
+    @include respond-to-max(sm) {
+      font-size: 1.25rem;
+    }
+  }
+
+  &__warning {
+    display: flex;
+    gap: 1rem;
+    padding: 1rem 1.25rem;
+    background: #fff7ed;
+    border: 1px solid #fed7aa;
+    border-radius: 0.5rem;
+    margin-bottom: 1.5rem;
+    align-items: flex-start;
+  }
+
+  &__warning-icon {
+    color: #ea580c;
+    flex-shrink: 0;
+    margin-top: 0.125rem;
+  }
+
+  &__warning-title {
+    font-weight: 600;
+    font-size: 0.9375rem;
+    color: #9a3412;
+    margin-bottom: 0.375rem;
+  }
+
+  &__warning-text {
+    font-size: 0.875rem;
+    color: #c2410c;
+    line-height: 1.5rem;
+    margin: 0;
+  }
+
+  &__confirm {
+    background: #fef2f2;
+    border: 1px solid #fecaca;
+    border-radius: 0.5rem;
+    padding: 1.25rem;
+    margin-bottom: 1.5rem;
+  }
+
+  &__confirm-text {
+    font-size: 0.9375rem;
+    color: #991b1b;
+    margin-bottom: 1rem;
+    line-height: 1.5rem;
+  }
+
+  &__actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+
+    @include respond-to-max(sm) {
+      flex-direction: column;
+    }
+  }
+
+  &__button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1.5rem;
+    border-radius: 0.5rem;
+    font-size: 0.9375rem;
+    font-weight: 500;
+    font-family: inherit;
+    cursor: pointer;
+    border: 1px solid transparent;
+    transition: all 0.2s ease;
+
+    &:disabled {
+      opacity: 0.7;
+      cursor: not-allowed;
+    }
+
+    @include respond-to-max(sm) {
+      width: 100%;
+    }
+
+    &--danger {
+      background: #dc2626;
+      color: #ffffff;
+      border-color: #dc2626;
+
+      &:hover:not(:disabled) {
+        background: #b91c1c;
+        border-color: #b91c1c;
+      }
+
+      &:focus-visible {
+        outline: 2px solid #dc2626;
+        outline-offset: 2px;
+      }
+    }
+
+    &--secondary {
+      background: #ffffff;
+      color: #374151;
+      border-color: #d0d5dd;
+
+      &:hover:not(:disabled) {
+        background: #f9fafb;
+        border-color: #98a2b3;
+      }
+
+      &:focus-visible {
+        outline: 2px solid $color-primary;
+        outline-offset: 2px;
+      }
+    }
+  }
+
+  &__spinner {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    border-top-color: #ffffff;
+    border-radius: 50%;
+    animation: rotate-spinner 0.6s linear infinite;
+    vertical-align: middle;
+  }
+}
+
+@keyframes rotate-spinner {
+  to {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/pages/socio-financiero/perfil/index.vue
+++ b/pages/socio-financiero/perfil/index.vue
@@ -1,254 +1,965 @@
-<script setup>
+<script lang="ts" setup>
+import { jwtDecode } from "jwt-decode";
+import { useAuth } from "@/composables/api";
+import { useDocuments } from "@/composables/api/useDocuments";
+import { onClickOutside } from "@vueuse/core";
+
 useSeoMeta({
   title: "Mi Perfil — Vitalink Seguros",
-  description: "Edita tu información de perfil como socio financiero en Vitalink.",
+  description:
+    "Edita tu información de perfil como socio financiero en Vitalink.",
   ogTitle: "Mi Perfil — Vitalink Seguros",
-  ogDescription: "Edita tu información de perfil como socio financiero en Vitalink.",
+  ogDescription:
+    "Edita tu información de perfil como socio financiero en Vitalink.",
 });
 
 definePageMeta({
-  middleware: ["auth-doctors-hospitals"],
+  middleware: ["auth-insurances"],
 });
-const config = useRuntimeConfig();
-const token = useCookie("token");
-const user_info = useCookie("user_info");
-const user = user_info.value;
-const firstName = ref(user.first_name || user.name);
-const lastName = ref(user.last_name);
-const phoneNumber = ref(user.phone_number || user.phone_number_1);
-const address = ref(user.address);
-const city = ref(user.city);
-const country_iso_code = ref(user.country_iso_code);
-const postal_code = ref(user.postal_code);
-const profilePicture = ref(null); // To store the selected file
-const imagePreview = ref(null); // To store the image preview URL
 
-const updateDoctor = async () => {
-  const { data: user, error } = await useFetch(
-    config.public.API_BASE_URL + "/doctors/update_doctor",
-    {
-      method: "PUT",
-      headers: { Authorization: token.value },
-      transform: (_user) => _user.data,
-      body: {
-        first_name: firstName,
-        last_name: lastName,
-        phone_number: phoneNumber,
-        address,
-        city,
-        country_iso_code,
-      },
-    }
+const { getUserInfo, setUserInfo } = useUserInfo();
+const { updateUser } = useAuth();
+const { addDocument } = useDocuments();
+const { getToken } = useAuthToken();
+const { show: showToast } = useToast();
+const logger = useLogger("SocioPerfilPersonal");
+
+const { id: userId } = jwtDecode<DecodedToken>(getToken()!);
+
+const name = ref("");
+const phoneNumber = ref("");
+const phoneCountryCode = ref("CRC");
+const address = ref("");
+const postalCode = ref("");
+const cityName = ref("");
+const countryIsoCode = ref("");
+
+const selectedProfileImage = ref<File | null>(null);
+const profileImagePreview = ref<string | null>(null);
+const isSubmitting = ref(false);
+const isUploadingImage = ref(false);
+
+const countryDropdownRef = ref<HTMLElement>();
+const countrySearchRef = ref<HTMLInputElement>();
+const isCountryDropdownOpen = ref(false);
+const countrySearchText = ref("");
+
+const countries = [
+  { code: "CRC", name: "Costa Rica" },
+  { code: "USA", name: "Estados Unidos" },
+  { code: "MEX", name: "México" },
+  { code: "GTM", name: "Guatemala" },
+  { code: "SLV", name: "El Salvador" },
+  { code: "HND", name: "Honduras" },
+  { code: "NIC", name: "Nicaragua" },
+  { code: "PAN", name: "Panamá" },
+  { code: "BLZ", name: "Belice" },
+  { code: "ESP", name: "España" },
+  { code: "COL", name: "Colombia" },
+  { code: "VEN", name: "Venezuela" },
+  { code: "PER", name: "Perú" },
+  { code: "CHL", name: "Chile" },
+  { code: "ARG", name: "Argentina" },
+  { code: "BRA", name: "Brasil" },
+  { code: "ECU", name: "Ecuador" },
+  { code: "BOL", name: "Bolivia" },
+  { code: "PRY", name: "Paraguay" },
+  { code: "URY", name: "Uruguay" },
+  { code: "DOM", name: "República Dominicana" },
+  { code: "CUB", name: "Cuba" },
+  { code: "PRI", name: "Puerto Rico" },
+];
+
+const countryPhoneCodes: Record<string, string> = {
+  CRC: "506",
+  USA: "1",
+  MEX: "52",
+  GTM: "502",
+  SLV: "503",
+  HND: "504",
+  NIC: "505",
+  PAN: "507",
+  BLZ: "501",
+  ESP: "34",
+  COL: "57",
+  VEN: "58",
+  PER: "51",
+  CHL: "56",
+  ARG: "54",
+  BRA: "55",
+  ECU: "593",
+  BOL: "591",
+  PRY: "595",
+  URY: "598",
+  DOM: "1",
+  CUB: "53",
+  PRI: "1",
+};
+
+const selectedCountry = computed(() =>
+  countries.find((c) => c.code === countryIsoCode.value),
+);
+
+const filteredCountries = computed(() => {
+  if (!countrySearchText.value.trim()) return countries;
+  return countries.filter((c) =>
+    c.name.toLowerCase().includes(countrySearchText.value.toLowerCase()),
   );
-  if (user) {
-    user_info.value = user.value;
-  }
-  if (error.value) {
-    console.log(error.value, "data");
+});
+
+const isValidImageUrl = (url: string | null | undefined): boolean =>
+  !!url && (url.startsWith("http://") || url.startsWith("https://"));
+
+const storedProfileImageUrl = computed<string | null>(() => {
+  const userInfo = getUserInfo() as IUser | null;
+  return isValidImageUrl(userInfo?.profile_picture_url)
+    ? (userInfo!.profile_picture_url ?? null)
+    : null;
+});
+
+const displayedImageSrc = computed(
+  () =>
+    profileImagePreview.value ||
+    storedProfileImageUrl.value ||
+    "/_nuxt/src/assets/picture.svg",
+);
+
+const hasProfileImage = computed(
+  () => !!profileImagePreview.value || !!storedProfileImageUrl.value,
+);
+
+const toggleCountryDropdown = () => {
+  isCountryDropdownOpen.value = !isCountryDropdownOpen.value;
+  if (isCountryDropdownOpen.value) {
+    nextTick(() => countrySearchRef.value?.focus());
   }
 };
 
-const handleFileChange = (event) => {
-  const file = event.target.files[0];
-  if (file) {
-    profilePicture.value = file; // Store the file
-    imagePreview.value = URL.createObjectURL(file); // Create a preview URL
-  }
+const selectCountry = (code: string) => {
+  countryIsoCode.value = code;
+  closeCountryDropdown();
 };
 
-const updateHospital = async () => {
-  const { data, error } = await useFetch(
-    config.public.API_BASE_URL + "/hospitals/update_hospital",
-    {
-      method: "PUT",
-      headers: { Authorization: token.value },
-      body: {
-        group_name: user.group_name,
-        medical_number: user.medical_number,
-        name: firstName,
-        phone_number_1: phoneNumber,
-        address,
-        city,
-        country_iso_code,
-        postal_code,
+const closeCountryDropdown = () => {
+  isCountryDropdownOpen.value = false;
+  countrySearchText.value = selectedCountry.value?.name ?? "";
+};
+
+const handleCountrySearchInput = () => {
+  if (!isCountryDropdownOpen.value) isCountryDropdownOpen.value = true;
+};
+
+const handleImageSelection = (event: Event) => {
+  const input = event.target as HTMLInputElement;
+  const file = input.files?.[0];
+  if (!file) return;
+
+  const allowedTypes = ["image/jpeg", "image/png", "image/webp"];
+  if (!allowedTypes.includes(file.type)) {
+    showToast("Formato no válido. Use JPG, PNG o WebP", "error");
+    input.value = "";
+    return;
+  }
+
+  if (file.size > 5 * 1024 * 1024) {
+    showToast("La imagen no debe superar los 5 MB", "error");
+    input.value = "";
+    return;
+  }
+
+  selectedProfileImage.value = file;
+  const reader = new FileReader();
+  reader.onload = (e) => {
+    profileImagePreview.value = e.target?.result as string;
+  };
+  reader.readAsDataURL(file);
+};
+
+const uploadProfileImage = async (): Promise<string | null> => {
+  if (!selectedProfileImage.value) return null;
+  isUploadingImage.value = true;
+  try {
+    const { data, error } = await addDocument({
+      file: selectedProfileImage.value,
+      fields: {
+        title: `profile_picture_${userId}`,
+        type: "IMG",
+        description: "Foto de perfil socio financiero",
+        id_for_table: String(userId),
+        table: "USER",
+        action_type: "GENERAL_GALLERY",
+        user_id: userId,
+        is_public: 1,
       },
+    });
+    if (error) {
+      showToast(error.info || "Error al subir la imagen", "error");
+      return null;
     }
-  );
-  if (error.value) {
-    console.log(error.value, "data");
+    return data?.url ?? null;
+  } finally {
+    isUploadingImage.value = false;
   }
 };
+
+const initializeForm = () => {
+  const userInfo = getUserInfo() as IUser | null;
+  if (!userInfo) return;
+
+  name.value = userInfo.name ?? "";
+  phoneNumber.value = userInfo.phone_number ?? "";
+  phoneCountryCode.value = userInfo.country_iso_code ?? "CRC";
+  address.value = userInfo.address ?? "";
+  postalCode.value = userInfo.postal_code ?? "";
+  cityName.value = userInfo.city_name ?? "";
+  countryIsoCode.value = userInfo.country_iso_code ?? "";
+  countrySearchText.value = selectedCountry.value?.name ?? "";
+};
+
+const handleSubmit = async () => {
+  if (!userId) {
+    showToast("No se encontró la información del usuario", "error");
+    return;
+  }
+
+  isSubmitting.value = true;
+  try {
+    let profilePictureUrl = storedProfileImageUrl.value ?? undefined;
+
+    if (selectedProfileImage.value) {
+      const uploaded = await uploadProfileImage();
+      if (!uploaded) return;
+      profilePictureUrl = uploaded;
+    }
+
+    const payload: IUserUpdateRequest = {
+      first_name: name.value.trim(),
+      phone_number: phoneNumber.value,
+      address: address.value,
+      postal_code: postalCode.value,
+      city_name: cityName.value,
+      country_iso_code: countryIsoCode.value,
+      ...(profilePictureUrl !== undefined && {
+        profile_picture_url: profilePictureUrl,
+      }),
+    };
+
+    logger.debug("updateUser payload", { userId, payload });
+
+    const { data, error } = await updateUser(userId, payload);
+
+    if (error) {
+      showToast(error.info || "Error al actualizar el perfil", "error");
+      return;
+    }
+
+    if (data) {
+      setUserInfo({ ...getUserInfo(), ...data });
+      selectedProfileImage.value = null;
+    }
+
+    showToast("Perfil actualizado exitosamente", "success");
+  } catch {
+    showToast("Error inesperado al actualizar el perfil", "error");
+  } finally {
+    isSubmitting.value = false;
+  }
+};
+
+onMounted(() => {
+  initializeForm();
+});
+
+onClickOutside(countryDropdownRef, () => {
+  closeCountryDropdown();
+});
 </script>
 
 <template>
   <NuxtLayout name="socio-dashboard-perfil">
-    <h4 class="fw-normal">Datos Personales</h4>
+    <h4 class="profile-form__title">Datos Personales</h4>
+
     <form
-      class="mt-4"
-      @submit.prevent="
-        user.last_name ? updateDoctor($event) : updateHospital($event)
-      "
+      class="profile-form"
+      novalidate
+      @submit.prevent="handleSubmit"
     >
-      <div class="form-group mb-3">
-        <label class="fw-normal">Foto de Perfil</label>
-        <div class="d-flex align-items-end">
-          <div class="profile-picture-container">
+      <!-- Profile picture -->
+      <div class="profile-form__field profile-form__field--avatar">
+        <span class="profile-form__label" id="photo-label">Foto de Perfil</span>
+        <div
+          class="profile-form__avatar-group"
+          role="group"
+          aria-labelledby="photo-label"
+        >
+          <figure class="profile-form__avatar">
             <img
-              :src="
-                imagePreview ||
-                user_info.profile_picture ||
-                '/_nuxt/src/assets/picture.svg'
-              "
-              :class="!profilePicture ? 'preview' : 'uploaded'"
-              alt="Profile Picture"
-            />
-          </div>
+              :src="displayedImageSrc"
+              :class="[
+                'profile-form__avatar-image',
+                hasProfileImage
+                  ? 'profile-form__avatar-image--filled'
+                  : 'profile-form__avatar-image--placeholder',
+              ]"
+              alt="Foto de perfil actual"
+            >
+          </figure>
           <label
             for="upload-picture"
-            class="bg-primary badge upload-picture-button mb-0"
+            class="profile-form__avatar-trigger"
+            role="button"
+            tabindex="0"
+            aria-label="Cambiar foto de perfil"
           >
-            <img src="@/src/assets/camera.svg" alt="Upload Picture" />
+            <img
+              src="@/src/assets/camera.svg"
+              alt=""
+              aria-hidden="true"
+            >
           </label>
           <input
-            type="file"
             id="upload-picture"
-            accept="image/*"
-            style="display: none"
-            @change="handleFileChange"
-          />
+            type="file"
+            accept="image/jpeg,image/png,image/webp"
+            class="profile-form__visually-hidden"
+            @change="handleImageSelection"
+          >
         </div>
       </div>
-      <div class="row row-cols-2">
-        <div class="form-group mb-3">
-          <label for="nombre" class="form-label text-capitalize"
-            >Nombre (s)</label
+
+      <!-- Name -->
+      <div class="profile-form__row profile-form__row--columns-1">
+        <div class="profile-form__field">
+          <label
+            for="nombre"
+            class="profile-form__label"
           >
+            Nombre
+          </label>
           <input
-            type="text"
-            class="form-control"
-            placeholder="Escribe tu nombre"
-            v-model="firstName"
-            name="nombre"
             id="nombre"
-          />
-        </div>
-        <div class="form-group mb-3">
-          <label for="apellido" class="form-label text-capitalize"
-            >Apellido (s)</label
-          >
-          <input
+            v-model="name"
             type="text"
-            class="form-control"
-            placeholder="Escribe tu apellido"
-            :value="user.last_name"
-            id="apellido"
-            name="apellido"
-          />
-        </div>
-        <div class="form-group mb-3">
-          <label class="form-label text-capitalize" for="telefono"
-            >Número de teléfono</label
+            class="profile-form__input"
+            placeholder="Nombre de la entidad o persona"
+            name="nombre"
           >
-          <input
-            type="phone"
-            placeholder="+1(555) 000-0000"
-            v-model="phoneNumber"
-            id="telefono"
-            name="telefono"
-            class="form-control"
-          />
         </div>
-        <div class="form-group mb-3">
+      </div>
+
+      <!-- Phone + Address -->
+      <div class="profile-form__row profile-form__row--columns-2">
+        <div class="profile-form__field">
+          <label
+            for="telefono"
+            class="profile-form__label"
+          >
+            Número de teléfono
+          </label>
+          <div class="profile-form__phone-group">
+            <select
+              v-model="phoneCountryCode"
+              class="profile-form__phone-select"
+              aria-label="Código de país"
+            >
+              <option
+                v-for="country in countries"
+                :key="country.code"
+                :value="country.code"
+              >
+                {{ country.code }} (+{{ countryPhoneCodes[country.code] }})
+              </option>
+            </select>
+            <input
+              id="telefono"
+              v-model="phoneNumber"
+              type="tel"
+              class="profile-form__input profile-form__phone-input"
+              placeholder="00000000"
+              name="telefono"
+            >
+          </div>
+        </div>
+
+        <div class="profile-form__field">
           <label
             for="direccion"
-            class="form-label text-capitalize"
-            name="direccion"
-            >Dirección</label
+            class="profile-form__label"
           >
+            Dirección
+          </label>
           <input
-            type="text"
-            placeholder="Dirección"
             id="direccion"
             v-model="address"
+            type="text"
+            class="profile-form__input"
+            placeholder="Dirección"
             name="direccion"
-            class="form-control"
-          />
-        </div>
-      </div>
-      <div class="row row-cols-3">
-        <div class="form-group mb-3">
-          <label class="form-label text-capitalize" for="postal"
-            >Código Postal</label
           >
-          <input
-            type="number"
-            placeholder="00000000"
-            id="postal"
-            name="postal"
-            v-model="postal_code"
-            class="form-control"
-          />
-        </div>
-        <div class="form-group mb-3">
-          <label class="form-label text-capitalize" for="ciudad">Ciudad*</label>
-          <input
-            type="text"
-            placeholder="Ciudad"
-            id="ciudad"
-            name="ciudad"
-            v-model="city"
-            class="form-control"
-            required
-          />
-        </div>
-        <div class="form-group mb-3">
-          <label class="form-label text-capitalize" for="pais">País</label>
-          <input
-            type="text"
-            placeholder="País"
-            id="pais"
-            name="pais"
-            v-model="country_iso_code"
-            class="form-control"
-            required
-          />
         </div>
       </div>
-      <div class="mt-5">
-        <button type="submit" class="btn btn-primary">Actualizar Perfil</button>
+
+      <!-- Postal + City + Country -->
+      <div class="profile-form__row profile-form__row--columns-3">
+        <div class="profile-form__field">
+          <label
+            for="postal"
+            class="profile-form__label"
+          >
+            Código Postal
+          </label>
+          <input
+            id="postal"
+            v-model="postalCode"
+            type="text"
+            class="profile-form__input"
+            placeholder="00000000"
+            name="postal"
+          >
+        </div>
+
+        <div class="profile-form__field">
+          <label
+            for="ciudad"
+            class="profile-form__label"
+          >
+            Ciudad*
+          </label>
+          <input
+            id="ciudad"
+            v-model="cityName"
+            type="text"
+            class="profile-form__input"
+            placeholder="Ciudad"
+            name="ciudad"
+            required
+          >
+        </div>
+
+        <div class="profile-form__field">
+          <label
+            for="pais"
+            class="profile-form__label"
+          >
+            País*
+          </label>
+          <div
+            ref="countryDropdownRef"
+            class="custom-dropdown"
+          >
+            <div
+              class="custom-dropdown__toggle"
+              :class="{
+                'custom-dropdown__toggle--active': isCountryDropdownOpen,
+              }"
+              @click="toggleCountryDropdown"
+            >
+              <input
+                ref="countrySearchRef"
+                v-model="countrySearchText"
+                type="text"
+                class="custom-dropdown__input"
+                :placeholder="!countryIsoCode ? 'Seleccionar país' : ''"
+                @input="handleCountrySearchInput"
+                @click.stop="isCountryDropdownOpen = true"
+              >
+              <svg
+                class="custom-dropdown__arrow"
+                :class="{
+                  'custom-dropdown__arrow--rotated': isCountryDropdownOpen,
+                }"
+                width="20"
+                height="20"
+                viewBox="0 0 20 20"
+                fill="none"
+              >
+                <path
+                  d="M5 7.5L10 12.5L15 7.5"
+                  stroke="currentColor"
+                  stroke-width="1.67"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </div>
+            <div
+              class="custom-dropdown__menu"
+              :class="{ 'custom-dropdown__menu--open': isCountryDropdownOpen }"
+            >
+              <div
+                v-if="filteredCountries.length === 0"
+                class="custom-dropdown__no-results"
+              >
+                No se encontraron países
+              </div>
+              <button
+                v-for="country in filteredCountries"
+                :key="country.code"
+                type="button"
+                class="custom-dropdown__item"
+                :class="{
+                  'custom-dropdown__item--active':
+                    countryIsoCode === country.code,
+                }"
+                @click="selectCountry(country.code)"
+              >
+                <span class="custom-dropdown__item-text">{{
+                  country.name
+                }}</span>
+                <svg
+                  v-if="countryIsoCode === country.code"
+                  class="custom-dropdown__item-check"
+                  width="16"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  fill="none"
+                >
+                  <path
+                    d="M13.5 4.5L6 12L2.5 8.5"
+                    stroke="currentColor"
+                    stroke-width="1.5"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="profile-form__actions">
+        <button
+          type="submit"
+          class="profile-form__button profile-form__button--primary"
+          :disabled="isSubmitting || isUploadingImage"
+          :aria-busy="isSubmitting || isUploadingImage"
+        >
+          <template v-if="isSubmitting || isUploadingImage">
+            <span
+              class="profile-form__spinner"
+              aria-hidden="true"
+            />
+            {{ isUploadingImage ? "Subiendo imagen..." : "Actualizando..." }}
+          </template>
+          <template v-else>
+            Actualizar Perfil
+          </template>
+        </button>
       </div>
     </form>
   </NuxtLayout>
 </template>
-<style>
-.profile-picture-container {
-  border-radius: 18px;
-  border: 3px solid var(--Primary-Gradients-Violet-02, #c2c6e9);
-  background: #f8faff;
-  width: 130px;
-  height: 132px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+
+<style lang="scss" scoped>
+.profile-form {
+  margin-top: 1.5rem;
+
+  @include respond-to-max(md) {
+    margin-top: 1.25rem;
+  }
+
+  @include respond-to-max(sm) {
+    margin-top: 1rem;
+  }
+
+  &__title {
+    font-weight: 400;
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+    margin-bottom: 1rem;
+    color: #212529;
+    font-family: $font-family-main;
+
+    @include respond-to-max(md) {
+      font-size: 1.375rem;
+      margin-bottom: 0.875rem;
+    }
+
+    @include respond-to-max(sm) {
+      font-size: 1.25rem;
+      margin-bottom: 0.75rem;
+    }
+  }
+
+  &__row {
+    display: grid;
+    gap: 1rem;
+    margin-bottom: 1rem;
+
+    @include respond-to-max(md) {
+      gap: 0.875rem;
+      margin-bottom: 0.875rem;
+    }
+
+    @include respond-to-max(sm) {
+      gap: 0.75rem;
+      margin-bottom: 0.75rem;
+    }
+
+    &--columns-1 {
+      grid-template-columns: 1fr;
+    }
+
+    &--columns-2 {
+      grid-template-columns: repeat(2, 1fr);
+
+      @include respond-to-max(md) {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    &--columns-3 {
+      grid-template-columns: repeat(3, 1fr);
+
+      @include respond-to-max(lg) {
+        grid-template-columns: repeat(2, 1fr);
+      }
+
+      @include respond-to-max(md) {
+        grid-template-columns: 1fr;
+      }
+    }
+  }
+
+  &__field {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 1rem;
+    gap: 0.5rem;
+
+    @include respond-to-max(md) {
+      margin-bottom: 0.75rem;
+      gap: 0.375rem;
+    }
+
+    @include respond-to-max(sm) {
+      margin-bottom: 0.5rem;
+    }
+
+    &--avatar {
+      margin-bottom: 1.5rem;
+    }
+  }
+
+  &__avatar-group {
+    display: flex;
+    align-items: flex-end;
+    gap: 0.625rem;
+  }
+
+  &__avatar {
+    margin: 0;
+    border-radius: 1.125rem;
+    border: 0.1875rem solid #c2c6e9;
+    background: #f8faff;
+    width: 8.125rem;
+    height: 8.25rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-shrink: 0;
+    overflow: hidden;
+
+    @include respond-to-max(md) {
+      width: 7rem;
+      height: 7.125rem;
+    }
+
+    @include respond-to-max(sm) {
+      width: 6rem;
+      height: 6.125rem;
+    }
+  }
+
+  &__avatar-image {
+    &--placeholder {
+      width: 2.5rem;
+      height: 2.5rem;
+      object-fit: contain;
+
+      @include respond-to-max(sm) {
+        width: 2rem;
+        height: 2rem;
+      }
+    }
+
+    &--filled {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+  }
+
+  &__avatar-trigger {
+    z-index: 10;
+    border-radius: 50%;
+    width: 2.5rem;
+    height: 2.5rem;
+    margin-left: -1.5625rem;
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: $color-primary;
+    flex-shrink: 0;
+    transition: all 0.2s ease;
+
+    @include respond-to-max(sm) {
+      width: 2rem;
+      height: 2rem;
+      margin-left: -1.125rem;
+    }
+
+    &:hover {
+      background-color: $color-primary-darkened-5;
+      transform: scale(1.05);
+    }
+
+    &:focus-visible {
+      outline: 2px solid $color-primary;
+      outline-offset: 2px;
+    }
+
+    img {
+      width: 1.25rem;
+      height: 1.25rem;
+
+      @include respond-to-max(sm) {
+        width: 1rem;
+        height: 1rem;
+      }
+    }
+  }
+
+  &__visually-hidden {
+    @include visually-hidden;
+  }
+
+  &__label {
+    @include form-label;
+  }
+
+  &__input {
+    @include input-base;
+  }
+
+  &__phone-group {
+    display: flex;
+    align-items: stretch;
+
+    &:has(.profile-form__phone-select:focus),
+    &:has(.profile-form__phone-input:focus) {
+      .profile-form__phone-select,
+      .profile-form__phone-input {
+        border-color: #3541b4;
+        box-shadow: none;
+        outline: none;
+      }
+    }
+  }
+
+  &__phone-select {
+    @include input-base;
+    flex-shrink: 0;
+    width: 130px;
+    border-right: none;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    cursor: pointer;
+    padding-right: 0.5rem;
+  }
+
+  &__phone-input {
+    flex: 1;
+    min-width: 0;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+
+  &__actions {
+    margin-top: 2rem;
+    display: flex;
+    justify-content: flex-start;
+    gap: 1rem;
+
+    @include respond-to-max(md) {
+      margin-top: 1.5rem;
+      flex-direction: column;
+    }
+  }
+
+  &__button {
+    &--primary {
+      @include primary-button;
+
+      @include respond-to-max(md) {
+        width: 100%;
+      }
+
+      &:disabled {
+        opacity: 0.7;
+        cursor: not-allowed;
+      }
+    }
+  }
+
+  &__spinner {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    border-top-color: $white;
+    border-radius: 50%;
+    animation: rotate-spinner 0.6s linear infinite;
+    margin-right: 8px;
+    vertical-align: middle;
+  }
 }
 
-.profile-picture-container .preview {
-  width: 40px;
-  height: 40px;
+@keyframes rotate-spinner {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
-.profile-picture-container .uploaded {
+.custom-dropdown {
+  position: relative;
   width: 100%;
-}
 
-.upload-picture-button {
-  border-radius: 39px;
-  width: 40px;
-  height: 40px;
-  margin-left: -25px;
-  cursor: pointer;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  &__toggle {
+    width: 100%;
+    min-height: 3rem;
+    padding: 0.75rem 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: #ffffff;
+    border: 1px solid #d0d5dd;
+    border-radius: 0.5rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+
+    &:hover {
+      border-color: #98a2b3;
+    }
+
+    &--active {
+      border-color: $color-primary;
+      box-shadow:
+        0 0 0 4px rgba(53, 65, 180, 0.2),
+        0 0 1.05px rgba(53, 65, 180, 0.4),
+        0 1.05px 2.1px rgba(50, 50, 71, 0.1);
+    }
+  }
+
+  &__input {
+    flex: 1;
+    border: none;
+    outline: none;
+    background: transparent;
+    color: #374151;
+    font-size: 1rem;
+    line-height: 1.5rem;
+    font-family: inherit;
+    padding: 0;
+    margin: 0;
+
+    &::placeholder {
+      color: #9ca3af;
+    }
+  }
+
+  &__arrow {
+    width: 1.25rem;
+    height: 1.25rem;
+    color: #9ca3af;
+    transition: transform 0.2s ease;
+    flex-shrink: 0;
+
+    &--rotated {
+      transform: rotate(180deg);
+    }
+  }
+
+  &__menu {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    z-index: 1000;
+    background: #ffffff;
+    border: 1px solid #d0d5dd;
+    border-radius: 0.5rem;
+    box-shadow:
+      0 0.25rem 0.375rem -0.0625rem rgba(0, 0, 0, 0.1),
+      0 0.125rem 0.25rem -0.0625rem rgba(0, 0, 0, 0.06);
+    max-height: 16rem;
+    overflow-y: auto;
+    margin-top: 0.25rem;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-0.625rem);
+    transition: all 0.2s ease;
+
+    &--open {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0);
+    }
+  }
+
+  &__no-results {
+    padding: 1rem;
+    font-size: 0.875rem;
+    color: #9ca3af;
+    font-style: italic;
+    text-align: center;
+  }
+
+  &__item {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    text-align: left;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    font-size: 1rem;
+    line-height: 1.5rem;
+    color: #374151;
+    transition: background-color 0.15s ease;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    font-family: inherit;
+
+    &:hover {
+      background-color: #f9fafb;
+    }
+
+    &:focus {
+      outline: none;
+      background-color: #f3f4f6;
+    }
+
+    &--active {
+      background-color: #f9fafb;
+      font-weight: 500;
+    }
+  }
+
+  &__item-text {
+    flex: 1;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-align: left;
+  }
+
+  &__item-check {
+    color: $color-primary;
+    flex-shrink: 0;
+  }
 }
 </style>

--- a/pages/socio-financiero/perfil/notificaciones.vue
+++ b/pages/socio-financiero/perfil/notificaciones.vue
@@ -1,64 +1,328 @@
-<script setup>
+<script lang="ts" setup>
 useSeoMeta({
   title: "Notificaciones — Vitalink Seguros",
-  description: "Configura tus preferencias de notificaciones como socio financiero en Vitalink.",
+  description:
+    "Configura tus preferencias de notificaciones como socio financiero en Vitalink.",
   ogTitle: "Notificaciones — Vitalink Seguros",
-  ogDescription: "Configura tus preferencias de notificaciones como socio financiero en Vitalink.",
+  ogDescription:
+    "Configura tus preferencias de notificaciones como socio financiero en Vitalink.",
 });
 
 definePageMeta({
-  middleware: ["auth-pacientes"],
+  middleware: ["auth-insurances"],
+});
+
+const { show: showToast } = useToast();
+const logger = useLogger("SocioPerfilNotificaciones");
+
+const STORAGE_KEY = "vitalink_socio_notification_preferences";
+
+const receiveNotifications = ref(true);
+const notifyConfirmed = ref(true);
+const notifyCancelled = ref(true);
+const isSubmitting = ref(false);
+
+const loadPreferences = () => {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (!saved) return;
+    const prefs = JSON.parse(saved);
+    receiveNotifications.value = prefs.receiveNotifications ?? true;
+    notifyConfirmed.value = prefs.notifyConfirmed ?? true;
+    notifyCancelled.value = prefs.notifyCancelled ?? true;
+    logger.debug("Notification preferences loaded");
+  } catch (err) {
+    logger.error("Error loading notification preferences", { err });
+  }
+};
+
+const handleSubmit = () => {
+  isSubmitting.value = true;
+  try {
+    const prefs = {
+      receiveNotifications: receiveNotifications.value,
+      notifyConfirmed: notifyConfirmed.value,
+      notifyCancelled: notifyCancelled.value,
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+    logger.debug("Notification preferences saved", prefs);
+    showToast("Preferencias actualizadas exitosamente", "success");
+  } catch (err) {
+    logger.error("Error saving notification preferences", { err });
+    showToast("Error al actualizar las preferencias", "error");
+  } finally {
+    isSubmitting.value = false;
+  }
+};
+
+onMounted(() => {
+  loadPreferences();
 });
 </script>
 
 <template>
   <NuxtLayout name="socio-dashboard-perfil">
-    <form class="mt-4" @submit.prevent="updateUser">
-      <div>
-        <p>
+    <h4 class="notif-form__title">
+      Notificaciones
+    </h4>
+
+    <form
+      class="notif-form"
+      novalidate
+      @submit.prevent="handleSubmit"
+    >
+      <div class="notif-form__section">
+        <p class="notif-form__description">
           Recibe notificaciones para estar al corriente de todo lo que surja.
         </p>
-        <div
-          class="form-check d-flex align-items-center justify-content-start gap-2 form-switch rounded-5 p-0 fw-light"
-        >
-          <input
-            class="form-check-reverse form-check-input m-0"
-            type="checkbox"
+
+        <label class="notif-form__toggle-row">
+          <span class="notif-form__toggle-label">
+            Quiero recibir notificaciones
+          </span>
+          <span
+            class="notif-form__toggle"
+            :class="{ 'notif-form__toggle--on': receiveNotifications }"
             role="switch"
-            id="flexSwitchCheckDefault"
-            v-model="isMapVisible"
-          />
-          <label class="form-check-label" for="flexSwitchCheckDefault"
-            >Quiero recibir notificaciones</label
+            :aria-checked="receiveNotifications"
+            tabindex="0"
+            @click="receiveNotifications = !receiveNotifications"
+            @keydown.enter.prevent="receiveNotifications = !receiveNotifications"
+            @keydown.space.prevent="receiveNotifications = !receiveNotifications"
           >
-        </div>
+            <span class="notif-form__toggle-thumb" />
+          </span>
+        </label>
       </div>
-      <div>
-        <p class="mt-4">
-          Cuando actives las siguientes notificaciones, recibirás una
-          notificación directamente en tu perfil
+
+      <div
+        class="notif-form__section"
+        :class="{ 'notif-form__section--disabled': !receiveNotifications }"
+      >
+        <p class="notif-form__description">
+          Cuando actives las siguientes notificaciones, recibirás un aviso
+          directamente en tu perfil.
         </p>
-        <div class="form-check">
-          <input class="form-check-input" type="checkbox" id="defaultCheck1" />
-          <label class="form-check-label text-secondary" for="defaultCheck1">
-            Recibir notificaciones de citas confirmadas
+
+        <div class="notif-form__checkboxes">
+          <label class="notif-form__checkbox-row">
+            <input
+              v-model="notifyConfirmed"
+              type="checkbox"
+              class="notif-form__checkbox"
+              :disabled="!receiveNotifications"
+            >
+            <span class="notif-form__checkbox-label">
+              Recibir notificaciones de citas confirmadas
+            </span>
           </label>
-        </div>
-        <div class="form-check">
-          <input
-            class="form-check-input"
-            type="checkbox"
-            value=""
-            id="defaultCheck2"
-          />
-          <label class="form-check-label text-secondary" for="defaultCheck2">
-            Recibir notificaciones de citas canceladas
+
+          <label class="notif-form__checkbox-row">
+            <input
+              v-model="notifyCancelled"
+              type="checkbox"
+              class="notif-form__checkbox"
+              :disabled="!receiveNotifications"
+            >
+            <span class="notif-form__checkbox-label">
+              Recibir notificaciones de citas canceladas
+            </span>
           </label>
         </div>
       </div>
-      <div class="mt-5">
-        <button type="submit" class="btn btn-primary">Actualizar Perfil</button>
+
+      <div class="notif-form__actions">
+        <button
+          type="submit"
+          class="notif-form__button notif-form__button--primary"
+          :disabled="isSubmitting"
+          :aria-busy="isSubmitting"
+        >
+          <template v-if="isSubmitting">
+            <span
+              class="notif-form__spinner"
+              aria-hidden="true"
+            />
+            Actualizando...
+          </template>
+          <template v-else>
+            Actualizar Preferencias
+          </template>
+        </button>
       </div>
     </form>
   </NuxtLayout>
 </template>
+
+<style lang="scss" scoped>
+.notif-form {
+  margin-top: 1.5rem;
+
+  @include respond-to-max(md) {
+    margin-top: 1.25rem;
+  }
+
+  @include respond-to-max(sm) {
+    margin-top: 1rem;
+  }
+
+  &__title {
+    font-weight: 400;
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+    margin-bottom: 1rem;
+    color: #212529;
+    font-family: $font-family-main;
+
+    @include respond-to-max(md) {
+      font-size: 1.375rem;
+    }
+
+    @include respond-to-max(sm) {
+      font-size: 1.25rem;
+    }
+  }
+
+  &__section {
+    margin-bottom: 1.75rem;
+    transition: opacity 0.2s ease;
+
+    &--disabled {
+      opacity: 0.5;
+      pointer-events: none;
+    }
+  }
+
+  &__description {
+    font-size: 0.9375rem;
+    color: #6b7280;
+    margin-bottom: 1rem;
+    line-height: 1.5rem;
+  }
+
+  &__toggle-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.875rem 1rem;
+    background: #f8faff;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    cursor: pointer;
+  }
+
+  &__toggle-label {
+    font-size: 0.9375rem;
+    color: #374151;
+    font-weight: 500;
+    user-select: none;
+  }
+
+  &__toggle {
+    position: relative;
+    width: 2.75rem;
+    height: 1.5rem;
+    background: #d1d5db;
+    border-radius: 9999px;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+    flex-shrink: 0;
+    outline: none;
+
+    &:focus-visible {
+      box-shadow: 0 0 0 3px rgba(53, 65, 180, 0.3);
+    }
+
+    &--on {
+      background: $color-primary;
+    }
+  }
+
+  &__toggle-thumb {
+    position: absolute;
+    top: 0.1875rem;
+    left: 0.1875rem;
+    width: 1.125rem;
+    height: 1.125rem;
+    background: #ffffff;
+    border-radius: 50%;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+    transition: transform 0.2s ease;
+
+    .notif-form__toggle--on & {
+      transform: translateX(1.25rem);
+    }
+  }
+
+  &__checkboxes {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  &__checkbox-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    cursor: pointer;
+  }
+
+  &__checkbox {
+    width: 1.125rem;
+    height: 1.125rem;
+    flex-shrink: 0;
+    accent-color: $color-primary;
+    cursor: pointer;
+  }
+
+  &__checkbox-label {
+    font-size: 0.9375rem;
+    color: #374151;
+    user-select: none;
+  }
+
+  &__actions {
+    margin-top: 2rem;
+    display: flex;
+    justify-content: flex-start;
+
+    @include respond-to-max(md) {
+      margin-top: 1.5rem;
+    }
+  }
+
+  &__button {
+    &--primary {
+      @include primary-button;
+
+      @include respond-to-max(md) {
+        width: 100%;
+      }
+
+      &:disabled {
+        opacity: 0.7;
+        cursor: not-allowed;
+      }
+    }
+  }
+
+  &__spinner {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    border-top-color: $white;
+    border-radius: 50%;
+    animation: rotate-spinner 0.6s linear infinite;
+    margin-right: 8px;
+    vertical-align: middle;
+  }
+}
+
+@keyframes rotate-spinner {
+  to {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/pages/socio-financiero/perfil/privacidad.vue
+++ b/pages/socio-financiero/perfil/privacidad.vue
@@ -1,55 +1,430 @@
-<script setup>
+<script lang="ts" setup>
+import { jwtDecode } from "jwt-decode";
+import { useAuth } from "@/composables/api";
+
 useSeoMeta({
   title: "Privacidad y Seguridad — Vitalink Seguros",
-  description: "Actualiza tu correo y contraseña de acceso a tu cuenta de socio financiero.",
+  description:
+    "Actualiza tu correo y contraseña de acceso a tu cuenta de socio financiero.",
   ogTitle: "Privacidad y Seguridad — Vitalink Seguros",
-  ogDescription: "Actualiza tu correo y contraseña de acceso a tu cuenta de socio financiero.",
+  ogDescription:
+    "Actualiza tu correo y contraseña de acceso a tu cuenta de socio financiero.",
 });
 
 definePageMeta({
-  middleware: ["auth-pacientes"],
+  middleware: ["auth-insurances"],
+});
+
+const { updateUser } = useAuth();
+const { getToken } = useAuthToken();
+const { getUserInfo, setUserInfo } = useUserInfo();
+const { show: showToast } = useToast();
+const logger = useLogger("SocioPerfilPrivacidad");
+
+const { id: userId } = jwtDecode<DecodedToken>(getToken()!);
+
+const email = ref("");
+const newPassword = ref("");
+const confirmPassword = ref("");
+const isSubmitting = ref(false);
+const showNewPassword = ref(false);
+const showConfirmPassword = ref(false);
+
+const initializeForm = () => {
+  const userInfo = getUserInfo() as IUser | null;
+  email.value = userInfo?.email ?? "";
+};
+
+const handleSubmit = async () => {
+  if (!userId) {
+    showToast("No se encontró la información del usuario", "error");
+    return;
+  }
+
+  if (newPassword.value && newPassword.value !== confirmPassword.value) {
+    showToast("Las contraseñas no coinciden", "error");
+    return;
+  }
+
+  isSubmitting.value = true;
+  try {
+    const payload: IUserUpdateRequest = {
+      email: email.value.trim(),
+      ...(newPassword.value && { password: newPassword.value }),
+    };
+
+    logger.debug("updateUser payload", { userId, payload });
+
+    const { data, error } = await updateUser(userId, payload);
+
+    if (error) {
+      showToast(error.info || "Error al actualizar", "error");
+      return;
+    }
+
+    if (data) {
+      setUserInfo({ ...getUserInfo(), ...data });
+    }
+
+    newPassword.value = "";
+    confirmPassword.value = "";
+    showToast("Información actualizada exitosamente", "success");
+  } catch {
+    showToast("Error inesperado al actualizar", "error");
+  } finally {
+    isSubmitting.value = false;
+  }
+};
+
+onMounted(() => {
+  initializeForm();
 });
 </script>
 
 <template>
   <NuxtLayout name="socio-dashboard-perfil">
-    <form class="mt-4" @submit.prevent="updateUser">
-      <div>
-        <p class="fw-bold">Email, contraseña y seguridad</p>
-        <p>
-          Administra tus contraseñas, preferencias de inicio de sesión y métodos
-          de recuperación.
+    <h4 class="privacy-form__title">
+      Privacidad y Seguridad
+    </h4>
+
+    <form
+      class="privacy-form"
+      novalidate
+      @submit.prevent="handleSubmit"
+    >
+      <p class="privacy-form__description">
+        Administra tu correo electrónico, contraseña y preferencias de inicio de
+        sesión.
+      </p>
+
+      <!-- Email -->
+      <div class="privacy-form__section">
+        <p class="privacy-form__section-title">
+          Email y contraseña
         </p>
-        <div class="form-group mb-3">
-          <label for="nombre" class="form-label text-capitalize">Email*</label>
-          <input
-            type="mail"
-            class="form-control"
-            placeholder="Dra.Stephanie Powell@gmail..."
-            v-model="firstName"
-            name="nombre"
-            id="nombre"
-          />
+
+        <div class="privacy-form__row privacy-form__row--columns-1">
+          <div class="privacy-form__field">
+            <label
+              for="email"
+              class="privacy-form__label"
+            >
+              Correo electrónico*
+            </label>
+            <input
+              id="email"
+              v-model="email"
+              type="email"
+              class="privacy-form__input"
+              placeholder="correo@ejemplo.com"
+              name="email"
+              autocomplete="email"
+              required
+            >
+          </div>
         </div>
-        <div class="form-group mb-3">
-          <label for="nombre" class="form-label text-capitalize"
-            >Contraseña</label
-          >
-          <input
-            type="password"
-            class="form-control"
-            placeholder="*******************"
-            v-model="firstName"
-            name="nombre"
-            id="nombre"
-          />
+
+        <div class="privacy-form__row privacy-form__row--columns-2">
+          <div class="privacy-form__field">
+            <label
+              for="new-password"
+              class="privacy-form__label"
+            >
+              Nueva contraseña
+            </label>
+            <div class="privacy-form__password-group">
+              <input
+                id="new-password"
+                v-model="newPassword"
+                :type="showNewPassword ? 'text' : 'password'"
+                class="privacy-form__input privacy-form__password-input"
+                placeholder="Dejar en blanco para no cambiar"
+                name="new-password"
+                autocomplete="new-password"
+              >
+              <button
+                type="button"
+                class="privacy-form__password-toggle"
+                :aria-label="showNewPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'"
+                @click="showNewPassword = !showNewPassword"
+              >
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 20 20"
+                  fill="none"
+                >
+                  <template v-if="showNewPassword">
+                    <path
+                      d="M2 2L18 18M8.68 8.69A3 3 0 0011.32 11.31M6.09 6.1A7.96 7.96 0 002 10c1.73 3.3 5.14 5.5 8 5.5a7.93 7.93 0 003.4-.76M9.88 4.54C9.58 4.52 9.29 4.5 9 4.5c-3.53 0-6.69 2.14-8 5.5a8.37 8.37 0 001.63 2.47M13.91 13.91A7.96 7.96 0 0018 10c-1.31-3.36-4.47-5.5-8-5.5-.67 0-1.32.08-1.94.22"
+                      stroke="currentColor"
+                      stroke-width="1.5"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </template>
+                  <template v-else>
+                    <path
+                      d="M10 4.5C6.47 4.5 3.31 6.64 2 10c1.31 3.36 4.47 5.5 8 5.5s6.69-2.14 8-5.5c-1.31-3.36-4.47-5.5-8-5.5zM10 13a3 3 0 110-6 3 3 0 010 6z"
+                      stroke="currentColor"
+                      stroke-width="1.5"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </template>
+                </svg>
+              </button>
+            </div>
+          </div>
+
+          <div class="privacy-form__field">
+            <label
+              for="confirm-password"
+              class="privacy-form__label"
+            >
+              Confirmar contraseña
+            </label>
+            <div class="privacy-form__password-group">
+              <input
+                id="confirm-password"
+                v-model="confirmPassword"
+                :type="showConfirmPassword ? 'text' : 'password'"
+                class="privacy-form__input privacy-form__password-input"
+                placeholder="Repetir nueva contraseña"
+                name="confirm-password"
+                autocomplete="new-password"
+              >
+              <button
+                type="button"
+                class="privacy-form__password-toggle"
+                :aria-label="showConfirmPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'"
+                @click="showConfirmPassword = !showConfirmPassword"
+              >
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 20 20"
+                  fill="none"
+                >
+                  <template v-if="showConfirmPassword">
+                    <path
+                      d="M2 2L18 18M8.68 8.69A3 3 0 0011.32 11.31M6.09 6.1A7.96 7.96 0 002 10c1.73 3.3 5.14 5.5 8 5.5a7.93 7.93 0 003.4-.76M9.88 4.54C9.58 4.52 9.29 4.5 9 4.5c-3.53 0-6.69 2.14-8 5.5a8.37 8.37 0 001.63 2.47M13.91 13.91A7.96 7.96 0 0018 10c-1.31-3.36-4.47-5.5-8-5.5-.67 0-1.32.08-1.94.22"
+                      stroke="currentColor"
+                      stroke-width="1.5"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </template>
+                  <template v-else>
+                    <path
+                      d="M10 4.5C6.47 4.5 3.31 6.64 2 10c1.31 3.36 4.47 5.5 8 5.5s6.69-2.14 8-5.5c-1.31-3.36-4.47-5.5-8-5.5zM10 13a3 3 0 110-6 3 3 0 010 6z"
+                      stroke="currentColor"
+                      stroke-width="1.5"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </template>
+                </svg>
+              </button>
+            </div>
+          </div>
         </div>
       </div>
-      <div class="mt-5">
-        <button type="submit" class="btn btn-primary">
-          Cambiar Contraseña
+
+      <div class="privacy-form__actions">
+        <button
+          type="submit"
+          class="privacy-form__button privacy-form__button--primary"
+          :disabled="isSubmitting"
+          :aria-busy="isSubmitting"
+        >
+          <template v-if="isSubmitting">
+            <span
+              class="privacy-form__spinner"
+              aria-hidden="true"
+            />
+            Actualizando...
+          </template>
+          <template v-else>
+            Guardar Cambios
+          </template>
         </button>
       </div>
     </form>
   </NuxtLayout>
 </template>
+
+<style lang="scss" scoped>
+.privacy-form {
+  margin-top: 1.5rem;
+
+  @include respond-to-max(md) {
+    margin-top: 1.25rem;
+  }
+
+  @include respond-to-max(sm) {
+    margin-top: 1rem;
+  }
+
+  &__title {
+    font-weight: 400;
+    font-size: 1.5rem;
+    line-height: 1.75rem;
+    margin-bottom: 1rem;
+    color: #212529;
+    font-family: $font-family-main;
+
+    @include respond-to-max(md) {
+      font-size: 1.375rem;
+    }
+
+    @include respond-to-max(sm) {
+      font-size: 1.25rem;
+    }
+  }
+
+  &__description {
+    font-size: 0.9375rem;
+    color: #6b7280;
+    margin-bottom: 1.5rem;
+    line-height: 1.5rem;
+  }
+
+  &__section {
+    margin-bottom: 1.5rem;
+  }
+
+  &__section-title {
+    font-weight: 600;
+    font-size: 0.9375rem;
+    color: #374151;
+    margin-bottom: 1rem;
+  }
+
+  &__row {
+    display: grid;
+    gap: 1rem;
+    margin-bottom: 1rem;
+
+    @include respond-to-max(md) {
+      gap: 0.875rem;
+      margin-bottom: 0.875rem;
+    }
+
+    @include respond-to-max(sm) {
+      gap: 0.75rem;
+      margin-bottom: 0.75rem;
+    }
+
+    &--columns-1 {
+      grid-template-columns: 1fr;
+    }
+
+    &--columns-2 {
+      grid-template-columns: repeat(2, 1fr);
+
+      @include respond-to-max(md) {
+        grid-template-columns: 1fr;
+      }
+    }
+  }
+
+  &__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+
+    @include respond-to-max(md) {
+      gap: 0.375rem;
+    }
+  }
+
+  &__label {
+    @include form-label;
+  }
+
+  &__input {
+    @include input-base;
+  }
+
+  &__password-group {
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
+
+  &__password-input {
+    flex: 1;
+    padding-right: 3rem;
+  }
+
+  &__password-toggle {
+    position: absolute;
+    right: 0.75rem;
+    top: 50%;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    padding: 0.25rem;
+    cursor: pointer;
+    color: #9ca3af;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 0.25rem;
+    transition: color 0.15s ease;
+
+    &:hover {
+      color: #374151;
+    }
+
+    &:focus-visible {
+      outline: 2px solid $color-primary;
+      outline-offset: 2px;
+    }
+  }
+
+  &__actions {
+    margin-top: 2rem;
+    display: flex;
+    justify-content: flex-start;
+
+    @include respond-to-max(md) {
+      margin-top: 1.5rem;
+    }
+  }
+
+  &__button {
+    &--primary {
+      @include primary-button;
+
+      @include respond-to-max(md) {
+        width: 100%;
+      }
+
+      &:disabled {
+        opacity: 0.7;
+        cursor: not-allowed;
+      }
+    }
+  }
+
+  &__spinner {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    border-top-color: $white;
+    border-radius: 50%;
+    animation: rotate-spinner 0.6s linear infinite;
+    margin-right: 8px;
+    vertical-align: middle;
+  }
+}
+
+@keyframes rotate-spinner {
+  to {
+    transform: rotate(360deg);
+  }
+}
+</style>


### PR DESCRIPTION
Replace raw cookie/fetch usage with composables (useAuth, useAuthToken, useToast) across all socio-financiero profile pages (index, notificaciones, privacidad, eliminar-cuenta). Add two-phase confirmation UI and loading state to the account deletion flow. Fix a token-not-ready race condition on médico profile pages (especialidades, profesional) by deferring initialization until the auth token is available, with retry logic for failed supplier lookups.