### PR TITLE
Append UUID suffix to UDC code to prevent duplicate entry errors

### DIFF
--- a/pages/medicos/perfil/especialidades.vue
+++ b/pages/medicos/perfil/especialidades.vue
@@ -139,7 +139,7 @@ const submitSpecialty = async () => {
     const { data, error } = await createUdc({
       supplier_id: supplierId.value,
       name: trimmedName,
-      code: toNormalizedCode(trimmedName),
+      code: `${toNormalizedCode(trimmedName)}_${crypto.randomUUID().replace(/-/g, "").slice(0, 8)}`,
       type: "MEDICAL_SPECIALTY",
       father_code: "",
       description: "",
@@ -216,7 +216,7 @@ const submitProcedure = async () => {
       description: "",
       value1: "0",
       value2: "0",
-      code: toNormalizedCode(trimmedName),
+      code: `${toNormalizedCode(trimmedName)}_${crypto.randomUUID().replace(/-/g, "").slice(0, 8)}`,
     };
     console.log("[submitProcedure] payload", payload);
     const { data, error } = await createUdc(payload);


### PR DESCRIPTION
Re-creating a specialty or procedure with the same name previously triggered ER_DUP_ENTRY because the code field is unique in the DB and was derived deterministically from the name. Appending a random 8-char hex suffix ensures each creation produces a distinct code regardless of prior entries.