### PR TITLE
Add profile picture removal and refactor profile loading

### DIFF
--- a/pages/medicos/perfil/profesional.vue
+++ b/pages/medicos/perfil/profesional.vue
@@ -1,4 +1,9 @@
 <script setup lang="ts">
+import { jwtDecode } from "jwt-decode";
+import { useDocuments } from "~/composables/api/useDocuments";
+import { useSupplier } from "~/composables/api/useSupplier";
+import placeholderAvatar from "@/src/assets/picture.svg";
+
 useSeoMeta({
   title: "Perfil Profesional — Vitalink",
   description:
@@ -8,13 +13,15 @@ useSeoMeta({
     "Actualiza tu información profesional y datos de contacto en Vitalink.",
 });
 
-import { jwtDecode } from "jwt-decode";
-import { useDocuments } from "~/composables/api/useDocuments";
-import { useSupplier } from "~/composables/api/useSupplier";
-
 interface DecodedToken {
   id: string;
 }
+
+const ALLOWED_IMAGE_TYPES = ["image/jpeg", "image/png", "image/webp"];
+const MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024;
+const MAX_DETAIL_ATTEMPTS = 3;
+const POLL_INTERVAL_MS = 1_500;
+const MAX_POLL_DURATION_MS = 30_000;
 
 const { show: showToast } = useToast();
 const { updateSupplier, getSupplierById, getAllSuppliers } = useSupplier();
@@ -34,8 +41,6 @@ const isLoadingProfile = ref(true);
 const isUploadingImage = ref(false);
 const loadError = ref<string | null>(null);
 
-const isFormReady = computed(() => true);
-
 const isValidImageUrl = (url: string | null | undefined): boolean =>
   !!url && (url.startsWith("http://") || url.startsWith("https://"));
 
@@ -53,56 +58,72 @@ const displayedImageSrc = computed(
   () =>
     profileImagePreview.value ||
     storedProfileImageUrl.value ||
-    "/_nuxt/src/assets/picture.svg",
+    placeholderAvatar,
 );
 
 const notify = (message: string, type: "success" | "error") => {
   showToast(message, type);
 };
 
-const fetchSupplierProfile = async (attempt = 1) => {
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+const fetchSupplierProfile = async () => {
   isLoadingProfile.value = true;
   loadError.value = null;
 
   try {
-    const { data: suppliers, error: suppliersError } = await getAllSuppliers();
+    // Phase 1: poll until a supplier record exists (created asynchronously after registration)
+    const pollStart = Date.now();
+    let pollElapsed = 0;
 
-    if (suppliersError || !suppliers?.length) {
-      if (attempt < 3) {
-        await new Promise((resolve) => setTimeout(resolve, attempt * 800));
-        return fetchSupplierProfile(attempt + 1);
+    while (pollElapsed < MAX_POLL_DURATION_MS) {
+      const { data: suppliers, error: suppliersError } = await getAllSuppliers();
+
+      if (suppliersError) {
+        loadError.value = suppliersError.info ?? "Error al cargar el perfil del proveedor";
+        return;
       }
-      loadError.value =
-        suppliersError?.info || "No se encontró el perfil del proveedor";
+
+      if (suppliers?.length) {
+        supplierId.value = suppliers[0].id;
+        break;
+      }
+
+      await delay(POLL_INTERVAL_MS);
+      pollElapsed = Date.now() - pollStart;
+    }
+
+    if (!supplierId.value) {
+      loadError.value = "No se encontró el perfil del proveedor";
       return;
     }
 
-    supplierId.value = suppliers[0].id;
+    // Phase 2: fetch supplier detail with retry
+    for (let attempt = 1; attempt <= MAX_DETAIL_ATTEMPTS; attempt++) {
+      const canRetry = attempt < MAX_DETAIL_ATTEMPTS;
 
-    const { data, error } = await getSupplierById(supplierId.value);
+      try {
+        const { data, error } = await getSupplierById(supplierId.value!);
 
-    if (error) {
-      if (attempt < 3) {
-        await new Promise((resolve) => setTimeout(resolve, attempt * 800));
-        return fetchSupplierProfile(attempt + 1);
+        if (error) {
+          if (canRetry) { await delay(attempt * 800); continue; }
+          loadError.value = error.info ?? "Error al cargar el perfil profesional";
+          return;
+        }
+
+        if (data) {
+          supplierData.value = data;
+          profileDescription.value = data.description ?? "";
+          medicalEnrollmentNumber.value = data.num_medical_enrollment ?? "";
+          await migrateProfilePictureCodeToUrl();
+        }
+
+        return;
+      } catch {
+        if (canRetry) { await delay(attempt * 800); continue; }
+        loadError.value = "Error inesperado al cargar el perfil";
       }
-      loadError.value = error.info || "Error al cargar el perfil profesional";
-      return;
     }
-
-    if (data) {
-      supplierData.value = data;
-      profileDescription.value = data.description || "";
-      medicalEnrollmentNumber.value = data.num_medical_enrollment || "";
-
-      await migrateProfilePictureCodeToUrl();
-    }
-  } catch {
-    if (attempt < 3) {
-      await new Promise((resolve) => setTimeout(resolve, attempt * 800));
-      return fetchSupplierProfile(attempt + 1);
-    }
-    loadError.value = "Error inesperado al cargar el perfil";
   } finally {
     isLoadingProfile.value = false;
   }
@@ -112,8 +133,7 @@ const migrateProfilePictureCodeToUrl = async () => {
   if (!supplierId.value || !supplierData.value) return;
 
   const stored = supplierData.value.profile_picture_url;
-  if (isValidImageUrl(stored)) return;
-  if (!stored) return;
+  if (isValidImageUrl(stored) || !stored) return;
 
   const { data: doc, error } = await getDocumentByCode(stored);
   if (error || !doc?.url) return;
@@ -127,23 +147,30 @@ const migrateProfilePictureCodeToUrl = async () => {
   supplierData.value = { ...supplierData.value, profile_picture_url: doc.url };
 };
 
+const validateImageFile = (file: File): string | null => {
+  if (!ALLOWED_IMAGE_TYPES.includes(file.type))
+    return "Formato no válido. Use JPG, PNG o WebP";
+  if (file.size > MAX_IMAGE_SIZE_BYTES)
+    return "La imagen no debe superar los 5 MB";
+  return null;
+};
+
+const removeProfilePicture = () => {
+  selectedProfileImage.value = null;
+  profileImagePreview.value = null;
+  if (supplierData.value) {
+    supplierData.value = { ...supplierData.value, profile_picture_url: "" };
+  }
+};
+
 const handleImageSelection = (event: Event) => {
   const input = event.target as HTMLInputElement;
   const file = input.files?.[0];
-
   if (!file) return;
 
-  const allowedTypes = ["image/jpeg", "image/png", "image/webp"];
-  const maxSizeInBytes = 5 * 1024 * 1024;
-
-  if (!allowedTypes.includes(file.type)) {
-    notify("Formato no válido. Use JPG, PNG o WebP", "error");
-    input.value = "";
-    return;
-  }
-
-  if (file.size > maxSizeInBytes) {
-    notify("La imagen no debe superar los 5 MB", "error");
+  const validationError = validateImageFile(file);
+  if (validationError) {
+    notify(validationError, "error");
     input.value = "";
     return;
   }
@@ -185,7 +212,7 @@ const uploadProfileImage = async (): Promise<string | null> => {
       return null;
     }
 
-    return data?.url || null;
+    return data?.url ?? null;
   } catch {
     notify("Error inesperado al subir la imagen", "error");
     return null;
@@ -206,19 +233,15 @@ const submitProfileUpdate = async () => {
     let profilePictureUrl = storedProfileImageUrl.value ?? "";
 
     if (selectedProfileImage.value) {
-      const uploadedCode = await uploadProfileImage();
-
-      if (uploadedCode) {
-        profilePictureUrl = uploadedCode;
-      } else if (selectedProfileImage.value) {
-        return;
-      }
+      const uploadedUrl = await uploadProfileImage();
+      if (!uploadedUrl) return;
+      profilePictureUrl = uploadedUrl;
     }
 
     const payload: ISupplierUpdateRequest = {
       description: profileDescription.value.trim(),
       num_medical_enrollment: medicalEnrollmentNumber.value.trim(),
-      profile_picture_url: profilePictureUrl || "",
+      profile_picture_url: profilePictureUrl,
     };
 
     const { data, error } = await updateSupplier(supplierId.value, payload);
@@ -231,12 +254,9 @@ const submitProfileUpdate = async () => {
     if (data) {
       supplierData.value = {
         ...supplierData.value,
-        description: payload.description ?? supplierData.value.description,
-        num_medical_enrollment:
-          payload.num_medical_enrollment ??
-          supplierData.value.num_medical_enrollment,
-        profile_picture_url:
-          profilePictureUrl ?? supplierData.value.profile_picture_url,
+        description: payload.description,
+        num_medical_enrollment: payload.num_medical_enrollment,
+        profile_picture_url: profilePictureUrl,
       };
 
       selectedProfileImage.value = null;
@@ -323,9 +343,6 @@ onMounted(() => {
             <label
               for="profile-image-upload"
               class="professional-profile__avatar-trigger"
-              :class="{
-                'professional-profile__avatar-trigger--disabled': !isFormReady,
-              }"
               role="button"
               tabindex="0"
               aria-label="Cambiar foto de perfil"
@@ -345,10 +362,18 @@ onMounted(() => {
               type="file"
               accept="image/jpeg,image/png,image/webp"
               class="professional-profile__visually-hidden"
-              :disabled="!isFormReady"
               @change="handleImageSelection"
             />
           </div>
+
+          <button
+            v-if="hasProfileImage"
+            type="button"
+            class="professional-profile__remove-picture"
+            @click="removeProfilePicture"
+          >
+            Eliminar foto de perfil
+          </button>
         </div>
 
         <div class="professional-profile__field">
@@ -364,7 +389,6 @@ onMounted(() => {
             class="professional-profile__textarea"
             rows="3"
             placeholder="Escribe una descripción sobre ti y tu experiencia profesional"
-            :disabled="!isFormReady"
             aria-describedby="description-counter"
           />
           <span
@@ -386,7 +410,6 @@ onMounted(() => {
             type="text"
             class="professional-profile__input"
             placeholder="Escribe el número de tu matrícula"
-            :disabled="!isFormReady"
           />
         </div>
       </fieldset>
@@ -395,7 +418,6 @@ onMounted(() => {
         <button
           type="submit"
           class="professional-profile__submit"
-          :disabled="!isFormReady"
           :aria-busy="isSubmitting || isUploadingImage"
         >
           <template v-if="isSubmitting || isUploadingImage">
@@ -571,12 +593,12 @@ onMounted(() => {
       margin-left: -1.125rem;
     }
 
-    &:hover:not(&--disabled) {
+    &:hover {
       background-color: $color-primary-darkened-5;
       transform: scale(1.05);
     }
 
-    &:active:not(&--disabled) {
+    &:active {
       background-color: $color-primary-darkened-10;
       transform: scale(0.98);
     }
@@ -584,11 +606,6 @@ onMounted(() => {
     &:focus-visible {
       outline: 2px solid $color-primary;
       outline-offset: 2px;
-    }
-
-    &--disabled {
-      opacity: 0.6;
-      cursor: not-allowed;
     }
 
     img {
@@ -604,6 +621,24 @@ onMounted(() => {
         width: 1rem;
         height: 1rem;
       }
+    }
+  }
+
+  &__remove-picture {
+    display: inline-block;
+    margin-top: 0.5rem;
+    padding: 0;
+    background: none;
+    border: none;
+    font-family: $font-family-main;
+    font-size: 13px;
+    color: $color-text-muted;
+    cursor: pointer;
+    text-decoration: underline;
+    transition: color 0.15s ease;
+
+    &:hover {
+      color: $color-error;
     }
   }
 

--- a/pages/pacientes/cuenta.vue
+++ b/pages/pacientes/cuenta.vue
@@ -12,6 +12,7 @@ import { useDocuments } from "~/composables/api/useDocuments";
 import { useAuth } from "~/composables/api/useAuth";
 import type { DropdownItem } from "@/components/ui/dropdown-base.vue";
 import { onClickOutside } from "@vueuse/core";
+import picturePlaceholder from "@/src/assets/picture.svg";
 
 interface DecodedToken {
   id: string;
@@ -104,7 +105,7 @@ const displayedImageSrc = computed(
   () =>
     profileImagePreview.value ||
     storedProfileImageUrl.value ||
-    "/_nuxt/src/assets/picture.svg",
+    picturePlaceholder,
 );
 
 const phoneCountryDropdownItems = computed<DropdownItem[]>(() =>
@@ -151,6 +152,14 @@ const handleCountrySearchInput = () => {
 };
 
 // ─── Image handling ───────────────────────────────────────────────────────────
+const removeProfilePicture = () => {
+  selectedProfileImage.value = null;
+  profileImagePreview.value = null;
+  if (userData.value) {
+    userData.value = { ...userData.value, profile_picture_url: "" };
+  }
+};
+
 const handleImageSelection = (event: Event) => {
   const input = event.target as HTMLInputElement;
   const file = input.files?.[0];
@@ -192,19 +201,13 @@ const uploadProfileImage = async (): Promise<string | null> => {
     formData.append("user_id", userId);
     formData.append("is_public", "1");
 
-    console.log("--- UPLOAD PAYLOAD LOG ---");
-    for (let [key, value] of formData.entries()) {
-      console.log(`${key}:`, value);
-    }
-    console.log("--------------------------");
-
     const { data, error } = await addDocument({
       file: selectedProfileImage.value,
       fields: {
         title: `profile_picture_${userData.value.id}`,
         type: "IMG",
         description: "Foto de perfil de paciente",
-        "id_for_table": "6",
+        id_for_table: "6",
         table: "USER",
         action_type: "GENERAL_GALLERY",
         user_id: userId,
@@ -263,8 +266,8 @@ const fetchUserProfile = async () => {
       } else {
         console.warn(
           "[uploadProfileImage] No se encontró un ID numérico en la respuesta del usuario. " +
-          "Se enviará el UUID como id_for_table, lo cual probablemente causará un error 500 " +
-          "porque el backend espera un INT UNSIGNED en esa columna.",
+            "Se enviará el UUID como id_for_table, lo cual probablemente causará un error 500 " +
+            "porque el backend espera un INT UNSIGNED en esa columna.",
         );
       }
 
@@ -295,7 +298,7 @@ const submitProfileUpdate = async () => {
 
   isSubmitting.value = true;
   try {
-    let profilePictureUrl = storedProfileImageUrl.value ?? undefined;
+    let profilePictureUrl = storedProfileImageUrl.value ?? "";
 
     if (selectedProfileImage.value) {
       const uploadedUrl = await uploadProfileImage();
@@ -309,7 +312,9 @@ const submitProfileUpdate = async () => {
     const fullName =
       `${firstName.value.trim()} ${lastName.value.trim()}`.trim();
 
-    const rawBirthDate = (userData.value as any).birth_date as string | undefined;
+    const rawBirthDate = (userData.value as any).birth_date as
+      | string
+      | undefined;
     const safeBirthDate = rawBirthDate
       ? rawBirthDate.includes("T")
         ? rawBirthDate
@@ -378,23 +383,16 @@ onBeforeUnmount(() => {
 
     <form
       v-else
-      class="account-profile"
-      novalidate
-      @submit.prevent="submitProfileUpdate"
+      ovalidate
       aria-label="Formulario de perfil de cuenta"
+      @submit.prevent="submitProfileUpdate"
     >
-      <!-- ─── Profile Photo ─────────────────────────────────────────────── -->
       <fieldset class="account-profile__fieldset">
         <legend class="account-profile__visually-hidden">Foto de perfil</legend>
-
         <div class="account-profile__field">
-          <span class="account-profile__label" id="photo-label">
-            Foto de Perfil
-          </span>
-          <p class="account-profile__hint" id="photo-hint">
+          <p id="photo-hint" class="account-profile__hint">
             Esta será la foto que verán tus médicos y el equipo de Vitalink.
           </p>
-
           <div
             class="account-profile__avatar-group"
             role="group"
@@ -439,6 +437,15 @@ onBeforeUnmount(() => {
               @change="handleImageSelection"
             />
           </div>
+
+          <button
+            v-if="hasProfileImage"
+            type="button"
+            class="account-profile__remove-picture"
+            @click="removeProfilePicture"
+          >
+            Eliminar foto de perfil
+          </button>
         </div>
       </fieldset>
 
@@ -451,7 +458,10 @@ onBeforeUnmount(() => {
         </legend>
 
         <div class="account-profile__grid">
-          <!-- Row 1: Nombre | Apellido -->
+          <!-- Row
+              1: Nombre | Apel
+            l ido -->
+
           <div class="account-profile__field account-profile__field--half">
             <label for="first-name" class="account-profile__label">
               Nombre(s) <span class="account-profile__required">*</span>
@@ -480,7 +490,6 @@ onBeforeUnmount(() => {
             />
           </div>
 
-          <!-- Row 2: Teléfono | Dirección -->
           <div class="account-profile__field account-profile__field--half">
             <label for="telefono" class="account-profile__label">
               Número de teléfono
@@ -518,7 +527,6 @@ onBeforeUnmount(() => {
             />
           </div>
 
-          <!-- Row 3: Código Postal | Ciudad | País -->
           <div class="account-profile__field account-profile__field--third">
             <label for="postal" class="account-profile__label">
               Código Postal
@@ -657,7 +665,7 @@ onBeforeUnmount(() => {
             <span class="account-profile__spinner" aria-hidden="true" />
             {{ isUploadingImage ? "Subiendo imagen..." : "Actualizando..." }}
           </template>
-          <template v-else>Actualizar Perfil</template>
+          <template v-else> Actualizar Perfil </template>
         </button>
       </div>
     </form>
@@ -890,6 +898,24 @@ onBeforeUnmount(() => {
         width: 1rem;
         height: 1rem;
       }
+    }
+  }
+
+  &__remove-picture {
+    display: inline-block;
+    margin-top: 0.5rem;
+    padding: 0;
+    background: none;
+    border: none;
+    font-family: $font-family-main;
+    font-size: 13px;
+    color: $color-text-muted;
+    cursor: pointer;
+    text-decoration: underline;
+    transition: color 0.15s ease;
+
+    &:hover {
+      color: $color-error;
     }
   }
 


### PR DESCRIPTION
- Add "Eliminar foto de perfil" button to both medico and patient profile pages
- Replace hardcoded /_nuxt/ avatar placeholder path with a static import
- Refactor fetchSupplierProfile from recursive retry into a two-phase polling loop: first poll until a supplier record exists, then retry detail fetch with a cap
- Extract validateImageFile helper and named constants for image/poll limits
- Remove always-true isFormReady computed and all disabled states tied to it
- Drop debug console.log calls from patient profile image upload