### PR TITLE
Fix mobile horizontal scroll caused by navbar panel inside transformed header

### DIFF
--- a/components/website/navbar.vue
+++ b/components/website/navbar.vue
@@ -24,77 +24,77 @@
       >
         <span class="nav__toggle-icon" aria-hidden="true"></span>
       </button>
-
-      <div
-        v-show="isMenuOpen"
-        class="nav__overlay"
-        @click="closeMenu"
-        aria-hidden="true"
-      ></div>
-
-      <div
-        id="nav-menu"
-        class="nav__container"
-        :class="{ 'nav__container--open': isMenuOpen }"
-      >
-        <ul class="nav__menu" role="menu">
-          <li
-            v-for="item in menuItems"
-            :key="item.id"
-            class="nav__menu-item"
-            role="none"
-          >
-            <NuxtLink
-              :to="item.to"
-              class="nav__menu-link"
-              :aria-current="isCurrentSection(item.id) ? 'page' : undefined"
-              role="menuitem"
-              @click="closeMenu"
-            >
-              {{ item.label }}
-            </NuxtLink>
-          </li>
-        </ul>
-
-        <div
-          class="nav__actions"
-          :class="{ 'nav__actions--visible': isMenuOpen }"
-        >
-          <template v-if="isAuthenticated">
-            <button
-              class="nav__button--primary"
-              @click="handleLogout"
-              aria-label="Cerrar sesión de su cuenta"
-            >
-              Cerrar Sesión
-            </button>
-          </template>
-          <template v-else>
-            <NuxtLink
-              to="/auth/login"
-              class="nav__button--outline"
-              @click="closeMenu"
-              aria-label="Ingresar a su cuenta"
-            >
-              Ingresar
-            </NuxtLink>
-            <NuxtLink
-              to="/pacientes/registro"
-              class="nav__button--primary"
-              @click="closeMenu"
-              aria-label="Registrarse como nuevo usuario"
-            >
-              Registrarse
-            </NuxtLink>
-          </template>
-        </div>
-      </div>
     </nav>
 
     <div role="status" aria-live="polite" aria-atomic="true" class="sr-only">
       {{ statusMessage }}
     </div>
   </header>
+
+  <div
+    v-show="isMenuOpen"
+    class="nav__overlay"
+    @click="closeMenu"
+    aria-hidden="true"
+  ></div>
+
+  <div
+    id="nav-menu"
+    class="nav__container"
+    :class="{ 'nav__container--open': isMenuOpen }"
+  >
+    <ul class="nav__menu" role="menu">
+      <li
+        v-for="item in menuItems"
+        :key="item.id"
+        class="nav__menu-item"
+        role="none"
+      >
+        <NuxtLink
+          :to="item.to"
+          class="nav__menu-link"
+          :aria-current="isCurrentSection(item.id) ? 'page' : undefined"
+          role="menuitem"
+          @click="closeMenu"
+        >
+          {{ item.label }}
+        </NuxtLink>
+      </li>
+    </ul>
+
+    <div
+      class="nav__actions"
+      :class="{ 'nav__actions--visible': isMenuOpen }"
+    >
+      <template v-if="isAuthenticated">
+        <button
+          class="nav__button--primary"
+          @click="handleLogout"
+          aria-label="Cerrar sesión de su cuenta"
+        >
+          Cerrar Sesión
+        </button>
+      </template>
+      <template v-else>
+        <NuxtLink
+          to="/auth/login"
+          class="nav__button--outline"
+          @click="closeMenu"
+          aria-label="Ingresar a su cuenta"
+        >
+          Ingresar
+        </NuxtLink>
+        <NuxtLink
+          to="/pacientes/registro"
+          class="nav__button--primary"
+          @click="closeMenu"
+          aria-label="Registrarse como nuevo usuario"
+        >
+          Registrarse
+        </NuxtLink>
+      </template>
+    </div>
+  </div>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
The mobile nav panel and overlay were children of <header>, which applies transform: translateY(-100%) when hidden. CSS transforms on ancestors break position: fixed descendants, causing the off-screen panel to extend past the viewport's right edge and create horizontal overflow. Moved the panel and overlay outside <header> to restore correct fixed positioning.