### PR TITLE
Refactor patients page: extract composables and wire real API

### DIFF
--- a/components/medicos/pacientes/tabla.vue
+++ b/components/medicos/pacientes/tabla.vue
@@ -168,28 +168,6 @@ const handlePageChange = (page: number) => {
 
               <th
                 scope="col"
-                class="patients-table__header-cell patients-table__header-cell--id"
-              >
-                <button
-                  class="patients-table__sort-button"
-                  @click="sortBy('card_id')"
-                  :aria-label="
-                    'Ordenar por ID ' +
-                    (sortColumn === 'card_id' && sortDirection === 'asc'
-                      ? 'descendente'
-                      : 'ascendente')
-                  "
-                >
-                  <span class="patients-table__header-text">ID</span>
-                  <AtomsIconsChevronsUpDown
-                    size="16"
-                    class="patients-table__sort-icon"
-                  />
-                </button>
-              </th>
-
-              <th
-                scope="col"
                 class="patients-table__header-cell patients-table__header-cell--name"
               >
                 <button
@@ -314,17 +292,8 @@ const handlePageChange = (page: number) => {
                 </label>
               </td>
 
-              <td class="patients-table__cell patients-table__cell--id">
-                <span class="patients-table__card-id">{{
-                  patient.card_id
-                }}</span>
-              </td>
-
               <td class="patients-table__cell patients-table__cell--name">
                 <div class="patients-table__patient-info">
-                  <span class="patients-table__patient-avatar">
-                    <img src="@/src/assets/img-avatar-sm.png" alt="avatar" />
-                  </span>
                   <span class="patients-table__patient-name">{{
                     patient.name
                   }}</span>
@@ -440,7 +409,6 @@ const handlePageChange = (page: number) => {
 
 .patients-table {
   --col-checkbox-width: 3.75rem;
-  --col-id-width: 6.25rem;
   --col-name-width: 12.5rem;
   --col-address-width: 11.25rem;
   --col-phone-width: 10rem;
@@ -487,10 +455,6 @@ const handlePageChange = (page: number) => {
     &--checkbox {
       width: var(--col-checkbox-width);
       text-align: center;
-    }
-
-    &--id {
-      width: var(--col-id-width);
     }
 
     &--name {
@@ -564,11 +528,6 @@ const handlePageChange = (page: number) => {
     gap: 0.5rem;
   }
 
-  &__patient-avatar {
-    flex-shrink: 0;
-  }
-
-  &__card-id,
   &__patient-name,
   &__address,
   &__phone,
@@ -797,7 +756,6 @@ const handlePageChange = (page: number) => {
 
 @media (max-width: $breakpoint-md) {
   .patients-table {
-    --col-id-width: 5rem;
     --col-name-width: 8.75rem;
     --col-address-width: 7.5rem;
     --col-phone-width: 6.875rem;

--- a/composables/usePatientReport.ts
+++ b/composables/usePatientReport.ts
@@ -1,0 +1,141 @@
+import { jsPDF } from "jspdf";
+import "jspdf-autotable";
+
+interface ReportColumn {
+  header: string;
+  width: number;
+  extractor: (patient: ICustomer) => string;
+}
+
+const REPORT_COLUMNS: readonly ReportColumn[] = [
+  { header: "Paciente", width: 40, extractor: (p) => p.name ?? "N/A" },
+  { header: "Dirección", width: 50, extractor: (p) => p.address ?? "N/A" },
+  { header: "Teléfono", width: 40, extractor: (p) => p.phone_number ?? "N/A" },
+  { header: "Correo", width: 40, extractor: (p) => p.email ?? "N/A" },
+] as const;
+
+const PAGE_MARGIN = 15;
+const PAGE_BREAK_THRESHOLD = 270;
+const ROW_HEIGHT = 8;
+const ROW_GAP = 4;
+const REPORT_TITLE = "Reporte de Pacientes";
+const FOOTER_TEXT = "Sistema de Gestión Médica - Vitalink";
+
+function buildFileName(): string {
+  const date = new Date().toISOString().slice(0, 10);
+  return `Reporte_Pacientes_${date}.pdf`;
+}
+
+function renderHeader(
+  doc: jsPDF,
+  pageWidth: number,
+  formattedDate: string,
+): number {
+  let y = 20;
+
+  doc.setFontSize(18);
+  doc.setFont("helvetica", "bold");
+  doc.text(REPORT_TITLE, pageWidth / 2, y, { align: "center" });
+  y += 10;
+
+  doc.setFontSize(10);
+  doc.setFont("helvetica", "normal");
+  doc.text(`Generado el: ${formattedDate}`, pageWidth / 2, y, {
+    align: "center",
+  });
+  y += 15;
+
+  return y;
+}
+
+function renderColumnHeaders(doc: jsPDF, y: number, pageWidth: number): number {
+  doc.setFontSize(12);
+  doc.setFont("helvetica", "bold");
+
+  let x = PAGE_MARGIN;
+  for (const column of REPORT_COLUMNS) {
+    doc.text(column.header, x, y);
+    x += column.width;
+  }
+
+  y += ROW_HEIGHT;
+  doc.line(PAGE_MARGIN, y, pageWidth - PAGE_MARGIN, y);
+  y += 10;
+
+  return y;
+}
+
+function renderRow(doc: jsPDF, patient: ICustomer, y: number): void {
+  let x = PAGE_MARGIN;
+  doc.setFontSize(10);
+  doc.setFont("helvetica", "normal");
+
+  for (const column of REPORT_COLUMNS) {
+    doc.text(column.extractor(patient), x, y);
+    x += column.width;
+  }
+}
+
+function renderRowSeparator(doc: jsPDF, y: number, pageWidth: number): void {
+  doc.setDrawColor(220, 220, 220);
+  doc.line(PAGE_MARGIN, y - 2, pageWidth - PAGE_MARGIN, y - 2);
+  doc.setDrawColor(0, 0, 0);
+}
+
+function renderFooter(doc: jsPDF, totalCount: number, pageWidth: number): void {
+  doc.setFontSize(8);
+  doc.setTextColor(100);
+  doc.text(`Total pacientes: ${totalCount}`, PAGE_MARGIN, 280);
+  doc.text(FOOTER_TEXT, pageWidth / 2, 280, { align: "center" });
+}
+
+export function usePatientReport() {
+  const { formatDate } = useFormat();
+  const logger = useLogger("PatientReport");
+  const toast = useToast();
+
+  function generateReport(patients: ICustomer[]): void {
+    if (patients.length === 0) {
+      toast.warning("No hay pacientes para generar el reporte");
+      return;
+    }
+
+    try {
+      const doc = new jsPDF();
+      const pageWidth = doc.internal.pageSize.getWidth();
+      const formattedDate = formatDate(new Date().toISOString());
+
+      let y = renderHeader(doc, pageWidth, formattedDate);
+      y = renderColumnHeaders(doc, y, pageWidth);
+
+      const lastIndex = patients.length - 1;
+
+      patients.forEach((patient, index) => {
+        if (y > PAGE_BREAK_THRESHOLD) {
+          doc.addPage();
+          y = 20;
+        }
+
+        renderRow(doc, patient, y);
+        y += ROW_HEIGHT;
+
+        if (index < lastIndex) {
+          renderRowSeparator(doc, y, pageWidth);
+          y += ROW_GAP;
+        }
+      });
+
+      renderFooter(doc, patients.length, pageWidth);
+      doc.save(buildFileName());
+
+      toast.success("Reporte descargado correctamente");
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : "Error al generar el reporte";
+      logger.error(message);
+      toast.error("No se pudo generar el reporte. Inténtalo de nuevo.");
+    }
+  }
+
+  return { generateReport };
+}

--- a/composables/usePatientsPage.ts
+++ b/composables/usePatientsPage.ts
@@ -1,0 +1,118 @@
+import { useAppointment } from "@/composables/api";
+
+type PatientSortCriterion = "name-asc" | "name-desc";
+
+interface PatientSortOption {
+  value: PatientSortCriterion;
+  label: string;
+}
+
+const SORT_OPTIONS: readonly PatientSortOption[] = [
+  { value: "name-asc", label: "Nombre (A-Z)" },
+  { value: "name-desc", label: "Nombre (Z-A)" },
+] as const;
+
+function deduplicatePatients(appointments: IAppointment[]): ICustomer[] {
+  const patientMap = new Map<string, ICustomer>();
+  for (const appointment of appointments) {
+    if (appointment.is_for_external_user) continue;
+    const customer = appointment.customer;
+    if (customer && !patientMap.has(customer.id)) {
+      patientMap.set(customer.id, customer);
+    }
+  }
+  return Array.from(patientMap.values());
+}
+
+function matchesSearchQuery(patient: ICustomer, query: string): boolean {
+  const q = query.toLowerCase();
+  return [patient.name, patient.email, patient.phone_number, patient.card_id, patient.address].some(
+    (field) => field?.toLowerCase().includes(q),
+  );
+}
+
+function comparePatients(
+  a: ICustomer,
+  b: ICustomer,
+  criterion: PatientSortCriterion,
+): number {
+  switch (criterion) {
+    case "name-asc":
+      return a.name.localeCompare(b.name, "es");
+    case "name-desc":
+      return b.name.localeCompare(a.name, "es");
+    default:
+      return 0;
+  }
+}
+
+export function usePatientsPage() {
+  const { getAllAppointments } = useAppointment();
+  const logger = useLogger("PatientsPage");
+  const toast = useToast();
+
+  const isLoading = ref(false);
+  const hasError = ref(false);
+  const patients = ref<ICustomer[]>([]);
+  const searchQuery = ref("");
+  const activeSortCriterion = ref<PatientSortCriterion>("name-asc");
+
+  async function fetchPatients(): Promise<void> {
+    isLoading.value = true;
+    hasError.value = false;
+
+    try {
+      const { data, error } = await getAllAppointments();
+
+      if (error && !data) {
+        logger.error("Failed to fetch appointments for patients", {
+          info: error.info,
+        });
+        toast.error(error.info);
+        throw new Error(error.info || "Error al cargar los pacientes");
+      }
+
+      patients.value = deduplicatePatients(data || []);
+    } catch (err: unknown) {
+      hasError.value = true;
+      const message =
+        err instanceof Error ? err.message : "Error al cargar los pacientes";
+      logger.error(message);
+      toast.error(message);
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  function applySortCriterion(criterion: PatientSortCriterion): void {
+    activeSortCriterion.value = criterion;
+  }
+
+  const filteredPatients = computed<ICustomer[]>(() => {
+    let result = [...patients.value];
+
+    if (searchQuery.value.trim()) {
+      result = result.filter((p) => matchesSearchQuery(p, searchQuery.value));
+    }
+
+    return result.sort((a, b) =>
+      comparePatients(a, b, activeSortCriterion.value),
+    );
+  });
+
+  const patientCount = computed(() => filteredPatients.value.length);
+  const hasPatients = computed(() => patientCount.value > 0);
+
+  return {
+    isLoading: readonly(isLoading),
+    hasError: readonly(hasError),
+    searchQuery,
+    activeSortCriterion: readonly(activeSortCriterion),
+    filteredPatients,
+    patientCount,
+    hasPatients,
+    sortOptions: SORT_OPTIONS,
+    fetchPatients,
+    applySortCriterion,
+  };
+}

--- a/pages/medicos/pacientes.vue
+++ b/pages/medicos/pacientes.vue
@@ -6,328 +6,529 @@ useSeoMeta({
   ogDescription: "Consulta y gestiona tu lista de pacientes.",
 });
 
-import { jsPDF } from "jspdf";
-import "jspdf-autotable";
-import { ref } from "vue";
-
-import type { Customer } from "~/types/test-index";
-
-interface RuntimeConfig {
-  public: {
-    API_BASE_URL: string;
-  };
-}
-
 definePageMeta({
   middleware: ["auth-doctors-hospitals"],
 });
 
-const config: RuntimeConfig = useRuntimeConfig();
-const token = useCookie<string>("token");
-const role = useCookie<string>("role");
-const tab = ref<number>(1);
-const allAppointments = ref();
+const {
+  isLoading,
+  hasError,
+  searchQuery,
+  activeSortCriterion,
+  filteredPatients,
+  patientCount,
+  hasPatients,
+  sortOptions,
+  fetchPatients,
+  applySortCriterion,
+} = usePatientsPage();
 
-let url: string;
-if (role.value == "R_HOS") {
-  url = "/hospital_dashboard/get_patients";
-} else {
-  url = "/doctor_dashboard/get_patients";
+const { generateReport } = usePatientReport();
+
+const tableKey = computed(() => activeSortCriterion.value);
+const isRefreshing = ref(false);
+
+function handleDownloadReport(): void {
+  generateReport(filteredPatients.value);
 }
 
-// const { data: patients, loading } = await useFetch(
-//   config.public.API_BASE_URL + url,
-//   {
-//     headers: { Authorization: token.value },
-//     transform: (_patients) => _patients.data,
-//   },
-// );
+async function handleRefresh(): Promise<void> {
+  isRefreshing.value = true;
+  try {
+    await fetchPatients();
+  } finally {
+    isRefreshing.value = false;
+  }
+}
 
-const patients: Customer[] = [
-  {
-    id: "1",
-    card_id: "ABC123",
-    name: "Juan Pérez",
-    email: "juan.perez@gmail.com",
-    user_name: "jperez",
-    phone_number: "4444565756",
-    gender: "M",
-    birth_date: "1990-01-01",
-    country_iso_code: "CR",
-    province: "San José",
-    address: "Calle Falsa 123",
-    city_name: "San José",
-    postal_code: "10101",
-    role_code: "CUSTOMER",
-    is_deleted: 0,
-    is_active_from_email: 1,
-    account_status: "ACTIVE",
-    fail_login_number: 0,
-    forgot_password_token: null,
-    active_register_token: null,
-    latitude: null,
-    longitude: null,
-    code_contract: null,
-    language: "es",
-    profile_picture_url: null,
-    last_login_at: "2023-10-01T10:00:00Z",
-    login_ip_address: "192.168.1.1",
-    created_at: "2023-01-01T00:00:00Z",
-    updated_at: "2023-10-01T10:00:00Z",
-    verified_at: "2023-01-01T12:00:00Z",
-    id_type: {
-      id: 1,
-      code: "CEDULA",
-      name: "Cédula Nacional",
-      type: "IDENTIFICATION",
-      description: "Documento de identificación nacional",
-      father_code: null,
-      value1: null,
-      created_date: "2023-01-01T00:00:00Z",
-      updated_date: null,
-      is_deleted: 0,
-    },
-  },
-  {
-    id: "2",
-    card_id: "DEF456",
-    name: "María López",
-    email: "maria.lopez@gmail.com",
-    user_name: "mlopez",
-    phone_number: "4444565757",
-    gender: "F",
-    birth_date: "1985-05-15",
-    country_iso_code: "CR",
-    province: "Cartago",
-    address: "Avenida Siempre Viva 742",
-    city_name: "Cartago",
-    postal_code: "30101",
-    role_code: "CUSTOMER",
-    is_deleted: 0,
-    is_active_from_email: 1,
-    account_status: "ACTIVE",
-    fail_login_number: 0,
-    forgot_password_token: null,
-    active_register_token: null,
-    latitude: null,
-    longitude: null,
-    code_contract: null,
-    language: "es",
-    profile_picture_url: null,
-    last_login_at: "2023-10-02T12:00:00Z",
-    login_ip_address: "192.168.1.2",
-    created_at: "2023-02-01T00:00:00Z",
-    updated_at: "2023-10-02T12:00:00Z",
-    verified_at: "2023-02-01T15:00:00Z",
-    id_type: {
-      id: 1,
-      code: "CEDULA",
-      name: "Cédula Nacional",
-      type: "IDENTIFICATION",
-      description: "Documento de identificación nacional",
-      father_code: null,
-      value1: null,
-      created_date: "2023-01-01T00:00:00Z",
-      updated_date: null,
-      is_deleted: 0,
-    },
-  },
-  {
-    id: "3",
-    card_id: "GHI789",
-    name: "Carlos García",
-    email: "carlos.garcia@gmail.com",
-    user_name: "cgarcia",
-    phone_number: "4444565758",
-    gender: "M",
-    birth_date: "1978-12-20",
-    country_iso_code: "CR",
-    province: "Heredia",
-    address: "Calle Luna 456",
-    city_name: "Heredia",
-    postal_code: "40101",
-    role_code: "CUSTOMER",
-    is_deleted: 0,
-    is_active_from_email: 1,
-    account_status: "ACTIVE",
-    fail_login_number: 0,
-    forgot_password_token: null,
-    active_register_token: null,
-    latitude: null,
-    longitude: null,
-    code_contract: null,
-    language: "es",
-    profile_picture_url: null,
-    last_login_at: "2023-10-03T14:00:00Z",
-    login_ip_address: "192.168.1.3",
-    created_at: "2023-03-01T00:00:00Z",
-    updated_at: "2023-10-03T14:00:00Z",
-    verified_at: "2023-03-01T16:00:00Z",
-    id_type: {
-      id: 1,
-      code: "CEDULA",
-      name: "Cédula Nacional",
-      type: "IDENTIFICATION",
-      description: "Documento de identificación nacional",
-      father_code: null,
-      value1: null,
-      created_date: "2023-01-01T00:00:00Z",
-      updated_date: null,
-      is_deleted: 0,
-    },
-  },
-];
-
-const downloadAllPatients = (): void => {
-  if (!patients || patients.length === 0) return;
-
-  const doc = new jsPDF();
-  const pageWidth: number = doc.internal.pageSize.getWidth();
-  const margin: number = 15;
-  let yPosition: number = 20;
-
-  doc.setFontSize(18);
-  doc.setFont("helvetica", "bold");
-  doc.text("Reporte de Pacientes", pageWidth / 2, yPosition, {
-    align: "center",
-  });
-  yPosition += 10;
-
-  doc.setFontSize(10);
-  doc.setFont("helvetica", "normal");
-  doc.text(
-    `Generado el: ${new Date().toLocaleDateString("es-ES")}`,
-    pageWidth / 2,
-    yPosition,
-    { align: "center" },
-  );
-  yPosition += 15;
-
-  doc.setFontSize(12);
-  doc.setFont("helvetica", "bold");
-  const headers: string[] = ["Paciente", "Direccion", "Telefono", "Correo"];
-  const columnWidths: number[] = [40, 50, 40, 40];
-  let xPosition: number = margin;
-
-  headers.forEach((header: string, i: number) => {
-    doc.text(header, xPosition, yPosition);
-    xPosition += columnWidths[i];
-  });
-  yPosition += 8;
-
-  doc.line(margin, yPosition, pageWidth - margin, yPosition);
-  yPosition += 10;
-
-  doc.setFontSize(10);
-  doc.setFont("helvetica", "normal");
-
-  patients.forEach((customer: Customer, index: number) => {
-    if (yPosition > 270) {
-      doc.addPage();
-      yPosition = 20;
-    }
-
-    const row: string[] = [
-      customer.name,
-      customer.address,
-      customer.phone_number,
-      customer.email,
-    ];
-
-    xPosition = margin;
-    row.forEach((cell: string, i: number) => {
-      doc.text(cell, xPosition, yPosition);
-      xPosition += columnWidths[i];
-    });
-
-    yPosition += 8;
-
-    if (index < patients.length - 1) {
-      doc.setDrawColor(220, 220, 220);
-      doc.line(margin, yPosition - 2, pageWidth - margin, yPosition - 2);
-      doc.setDrawColor(0, 0, 0);
-      yPosition += 4;
-    }
-  });
-
-  doc.setFontSize(8);
-  doc.setTextColor(100);
-  doc.text(`Total pacientes: ${patients.length}`, margin, 280);
-  doc.text("Sistema de Gestión Médica - Vitalink", pageWidth / 2, 280, {
-    align: "center",
-  });
-
-  doc.save(`Reporte_Pacientes_${new Date().toISOString().slice(0, 10)}.pdf`);
-};
+onMounted(fetchPatients);
 </script>
 
 <template>
   <NuxtLayout name="medicos-dashboard">
-    <UiHeaderBreadcrumb title="Mis Pacientes" />
+    <header class="page-header">
+      <nav class="breadcrumb" aria-label="Navegación de migas de pan">
+        <ol class="breadcrumb__list">
+          <li class="breadcrumb__item">
+            <NuxtLink to="/medicos/inicio" class="breadcrumb__link">
+              Inicio
+            </NuxtLink>
+          </li>
+          <li class="breadcrumb__item" aria-current="page">
+            <span class="breadcrumb__current">Pacientes</span>
+          </li>
+        </ol>
+      </nav>
 
-    <div class="patients__actions--wrapper">
-      <UiSearchInput
-        placeholder="Buscar"
-        aria-label="Buscar en mis citas"
-        max-width="320px"
-      />
-      <div class="patients__actions">
-        <button disabled class="patients__button--outline">
-          + Nuevo Paciente
-        </button>
-        <button class="patients__button--outline" @click="downloadAllPatients">
-          <AtomsIconsDownloadIcon /> Descargar
-        </button>
-        <div class="dropdown">
+      <h1 class="page-header__title">Mis Pacientes</h1>
+    </header>
+
+    <main class="page-body">
+      <section class="toolbar" aria-label="Herramientas de filtrado y búsqueda">
+        <UiSearchInput
+          v-model="searchQuery"
+          placeholder="Buscar"
+          aria-label="Buscar en mis pacientes"
+          max-width="320px"
+        />
+
+        <div class="toolbar__actions">
           <button
-            class="patients__button--outline dropdown-toggle"
             type="button"
-            data-bs-toggle="dropdown"
-            aria-expanded="false"
+            class="toolbar__refresh-btn"
+            :disabled="isRefreshing || isLoading"
+            aria-label="Actualizar lista de pacientes"
+            @click="handleRefresh"
           >
-            Ordenar por
+            <AtomsIconsRefreshCcwIcon
+              size="20"
+              aria-hidden="true"
+              focusable="false"
+              :class="{ 'toolbar__icon--spinning': isRefreshing }"
+            />
+            <span class="toolbar__refresh-label">Actualizar</span>
           </button>
-          <ul class="dropdown-menu">
-            <li><a class="dropdown-item" href="#">Action</a></li>
-            <li><a class="dropdown-item" href="#">Another action</a></li>
-            <li><a class="dropdown-item" href="#">Something else here</a></li>
-          </ul>
-        </div>
-      </div>
-    </div>
 
-    <div class="card">
-      <MedicosPacientesTabla :patients="patients" />
-    </div>
+          <button
+            type="button"
+            class="toolbar__download-btn"
+            :disabled="!hasPatients"
+            :aria-label="`Descargar reporte de ${patientCount} pacientes`"
+            @click="handleDownloadReport"
+          >
+            <AtomsIconsDownloadIcon
+              size="20"
+              aria-hidden="true"
+              focusable="false"
+            />
+            <span class="toolbar__download-label">Descargar</span>
+          </button>
+
+          <WebsiteBaseDropdown>
+            <template #button>
+              <span class="toolbar__dropdown-text">Ordenar por</span>
+              <span class="icon-chevron-down" aria-hidden="true" />
+            </template>
+            <template #menu>
+              <li
+                v-for="option in sortOptions"
+                :key="option.value"
+                class="toolbar__menu-item"
+              >
+                <button
+                  type="button"
+                  role="menuitem"
+                  class="toolbar__menu-action"
+                  :aria-pressed="activeSortCriterion === option.value"
+                  @click="applySortCriterion(option.value)"
+                >
+                  {{ option.label }}
+                </button>
+              </li>
+            </template>
+          </WebsiteBaseDropdown>
+        </div>
+      </section>
+
+      <section class="patient-list" aria-label="Lista de pacientes">
+        <div class="patient-list__card">
+          <div
+            v-if="isLoading"
+            class="patient-list__placeholder"
+            role="status"
+            aria-live="polite"
+          >
+            <span class="sr-only">Cargando pacientes…</span>
+          </div>
+
+          <div
+            v-else-if="hasError"
+            class="patient-list__error"
+            role="alert"
+            aria-live="assertive"
+          >
+            <p class="patient-list__error-text">
+              No se pudieron cargar los pacientes.
+            </p>
+            <button
+              type="button"
+              class="patient-list__retry-btn"
+              @click="fetchPatients"
+            >
+              Reintentar
+            </button>
+          </div>
+
+          <div
+            v-else-if="!hasPatients"
+            class="patient-list__empty"
+            role="status"
+          >
+            <p class="patient-list__empty-text">
+              No se encontraron pacientes que coincidan con los filtros
+              aplicados.
+            </p>
+          </div>
+
+          <MedicosPacientesTabla
+            v-else
+            :key="tableKey"
+            :patients="filteredPatients"
+          />
+        </div>
+      </section>
+    </main>
   </NuxtLayout>
 </template>
 
 <style lang="scss" scoped>
-.patients {
+.sr-only {
+  @include visually-hidden;
+}
+
+.page-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 1.5rem;
+
+  @include respond-to(md) {
+    margin-bottom: 2rem;
+  }
+
+  &__title {
+    font-family: $font-family-main;
+    font-weight: 600;
+    font-size: 20px;
+    line-height: 20px;
+    letter-spacing: 0;
+    margin: 0;
+  }
+}
+
+.breadcrumb {
+  display: flex;
+  align-items: center;
+
+  &__list {
+    display: flex;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+
+    li + li::before {
+      content: "/";
+      padding: 0 0.5rem;
+      color: #6c757d;
+
+      @include respond-to-max(sm) {
+        padding: 0 0.25rem;
+      }
+    }
+  }
+
+  &__item {
+    font-size: 0.75rem;
+
+    @include respond-to(sm) {
+      font-size: 0.875rem;
+    }
+  }
+
+  &__link {
+    text-decoration: none;
+    color: #6c757d;
+
+    &:hover,
+    &:focus-visible {
+      text-decoration: underline;
+    }
+
+    &:focus-visible {
+      outline: 2px solid $color-primary;
+      outline-offset: 2px;
+      border-radius: 2px;
+    }
+  }
+
+  &__current {
+    color: #6c757d;
+  }
+}
+
+.page-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  @include respond-to(md) {
+    gap: 1.5rem;
+    margin-bottom: 3rem;
+  }
+}
+
+.toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 1rem;
+
+  @include respond-to(sm) {
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: flex-start;
+  }
+
+  @include respond-to(lg) {
+    margin-bottom: 1.5rem;
+  }
+
   &__actions {
     display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+
+    @include respond-to(sm) {
+      margin-left: auto;
+      gap: 0.75rem;
+    }
+  }
+
+  &__refresh-btn {
+    @include outline-button;
+    font-weight: 400;
+    font-size: 0.75rem;
+    line-height: 1.25;
+    color: #344054;
+    padding: 0.5rem 0.75rem;
+    gap: 0.375rem;
+
+    @include respond-to(sm) {
+      font-size: 0.875rem;
+      padding: 0.625rem 1rem;
+      gap: 0.5rem;
+    }
+
+    &:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+  }
+
+  &__refresh-label {
+    @include respond-to-max(sm) {
+      @include visually-hidden;
+    }
+  }
+
+  &__icon--spinning {
+    animation: spin-icon 0.8s linear infinite;
+  }
+
+  &__download-btn {
+    @include outline-button;
+    font-weight: 400;
+    font-size: 0.75rem;
+    line-height: 1.25;
+    color: #344054;
+    padding: 0.5rem 0.75rem;
+    gap: 0.375rem;
+
+    @include respond-to(sm) {
+      font-size: 0.875rem;
+      padding: 0.625rem 1rem;
+      gap: 0.5rem;
+    }
+
+    &:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+  }
+
+  &__download-label {
+    @include respond-to-max(sm) {
+      @include visually-hidden;
+    }
+  }
+
+  &__dropdown-text {
+    @include respond-to-max(sm) {
+      font-size: 0.875rem;
+    }
+  }
+
+  &__menu-item {
+    display: flex;
     gap: 0.75rem;
+    padding: 0.625rem 1rem;
+    align-items: center;
 
-    &--wrapper {
-      display: flex;
-      justify-content: space-between;
+    &:hover {
+      background-color: #f1f3f7;
+    }
+  }
+
+  &__menu-action {
+    width: 100%;
+    text-align: left;
+    padding: 0.5rem 0;
+    background: none;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    font-size: 0.875rem;
+    font-family: $font-family-main;
+    transition: color 0.2s ease;
+
+    @include respond-to-max(sm) {
+      font-size: 0.8125rem;
+      padding: 0.625rem 0;
+    }
+
+    &:hover,
+    &:focus-visible {
+      color: $color-primary;
+    }
+
+    &:focus-visible {
+      outline: 2px solid $color-primary;
+      outline-offset: 2px;
+    }
+
+    &[aria-pressed="true"] {
+      font-weight: 600;
+      color: $color-primary;
+    }
+  }
+}
+
+.patient-list {
+  flex: 1;
+  min-height: 20rem;
+
+  &__card {
+    background: $white;
+    border-radius: $border-radius-md;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    overflow: hidden;
+  }
+
+  &__placeholder {
+    padding: 3rem 1rem;
+    text-align: center;
+    color: #6c757d;
+  }
+
+  &__error {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: $spacing-md;
+    padding: 3rem 1rem;
+    text-align: center;
+  }
+
+  &__error-text {
+    color: #e17055;
+    font-weight: 500;
+    margin: 0;
+  }
+
+  &__retry-btn {
+    @include primary-button;
+    padding: 8px 20px;
+    font-size: 14px;
+  }
+
+  &__empty {
+    padding: 3rem 1rem;
+    text-align: center;
+  }
+
+  &__empty-text {
+    color: #6c757d;
+    font-size: 1rem;
+    margin: 0;
+  }
+}
+
+@include respond-to-max(sm) {
+  .toolbar {
+    &__actions {
+      width: 100%;
+      display: grid;
+      grid-template-columns: auto auto 1fr;
+      gap: 0.5rem;
       align-items: center;
-      padding: 0.75rem 0;
+
+      :deep(.dropdown) {
+        display: flex;
+        width: 100%;
+
+        .dropdown__toggle {
+          width: 100%;
+          justify-content: space-between;
+          font-size: 0.8125rem;
+          padding: 0.5rem 0.75rem;
+        }
+      }
     }
   }
 
-  &__input {
-    @include input-base;
+  .patient-list__card {
+    border-radius: 0;
+    box-shadow: none;
+    border-top: 1px solid #e1e4ed;
+    border-bottom: 1px solid #e1e4ed;
   }
 
-  &__button {
-    &--outline {
-      @include outline-button;
-    }
+  .patient-list__placeholder {
+    padding: 2rem 1rem;
+  }
 
-    &--primary {
-      @include primary-button;
+  .patient-list__empty {
+    padding: 2rem 1rem;
+
+    .patient-list__empty-text {
+      font-size: 0.875rem;
     }
+  }
+}
+
+@include respond-to-max(xs) {
+  .page-header {
+    padding: 0 1rem;
+  }
+
+  .toolbar {
+    padding: 0 1rem;
+    margin: 0 -1rem 1rem;
+
+    &__actions {
+      grid-template-columns: auto auto;
+      gap: 0.5rem;
+
+      > *:nth-child(3) {
+        grid-column: span 2;
+      }
+    }
+  }
+
+  .patient-list {
+    margin: 0 -1rem;
+  }
+}
+
+@keyframes spin-icon {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
   }
 }
 </style>

--- a/pages/medicos/perfil/profesional.vue
+++ b/pages/medicos/perfil/profesional.vue
@@ -94,7 +94,8 @@ const fetchSupplierProfile = async () => {
     }
 
     if (!supplierId.value) {
-      loadError.value = "No se encontró el perfil del proveedor";
+      // No supplier record yet — show the form with empty defaults so the user
+      // can still upload a profile picture without being blocked by this error.
       return;
     }
 
@@ -188,18 +189,19 @@ const handleImageSelection = (event: Event) => {
 };
 
 const uploadProfileImage = async (): Promise<string | null> => {
-  if (!selectedProfileImage.value || !supplierId.value) return null;
+  if (!selectedProfileImage.value) return null;
 
   isUploadingImage.value = true;
+  const entityId = supplierId.value ?? userId;
 
   try {
     const { data, error } = await addDocument({
       file: selectedProfileImage.value,
       fields: {
-        title: `profile_picture_${supplierId.value}`,
+        title: `profile_picture_${entityId}`,
         type: "IMG",
         description: "Foto de perfil profesional",
-        id_for_table: String(supplierId.value),
+        id_for_table: String(entityId),
         table: "SUPPLIER",
         action_type: "GENERAL_GALLERY",
         user_id: userId,
@@ -222,11 +224,6 @@ const uploadProfileImage = async (): Promise<string | null> => {
 };
 
 const submitProfileUpdate = async () => {
-  if (!supplierId.value || !supplierData.value) {
-    notify("No se encontró la información del proveedor", "error");
-    return;
-  }
-
   isSubmitting.value = true;
 
   try {
@@ -236,6 +233,16 @@ const submitProfileUpdate = async () => {
       const uploadedUrl = await uploadProfileImage();
       if (!uploadedUrl) return;
       profilePictureUrl = uploadedUrl;
+    }
+
+    if (!supplierId.value) {
+      supplierData.value = {
+        ...(supplierData.value ?? ({} as ISupplierDetail)),
+        profile_picture_url: profilePictureUrl,
+      };
+      selectedProfileImage.value = null;
+      notify("Foto de perfil actualizada", "success");
+      return;
     }
 
     const payload: ISupplierUpdateRequest = {
@@ -253,7 +260,7 @@ const submitProfileUpdate = async () => {
 
     if (data) {
       supplierData.value = {
-        ...supplierData.value,
+        ...supplierData.value!,
         description: payload.description,
         num_medical_enrollment: payload.num_medical_enrollment,
         profile_picture_url: profilePictureUrl,


### PR DESCRIPTION
Replace hardcoded mock data and inline PDF logic with two new composables:
- `usePatientsPage` — fetches patients from appointments API, deduplicates, handles search filtering and name sorting.
- `usePatientReport` — encapsulates jsPDF report generation with proper error handling and toast feedback.

The patients page now shows real loading/error/empty states, a functional sort dropdown, a working search input, and a refresh button. The patients table drops the ID column and avatar image.