### PR TITLE
Fix CORS error on doctor profile by routing picture URL to PUT /user/edit

### DIFF
--- a/composables/api/index.ts
+++ b/composables/api/index.ts
@@ -11,3 +11,4 @@ export { useLanguageSupplier } from "./useLanguageSupplier";
 export { usePackage } from "./usePackage";
 export { useSupplier } from "./useSupplier";
 export { useUdc } from "./useUdc";
+export { useUser } from "./useUser";

--- a/composables/api/useUser.ts
+++ b/composables/api/useUser.ts
@@ -1,0 +1,72 @@
+import { useLogger } from "@/composables/useLogger";
+import useApi from "./useApi";
+
+export const useUser = () => {
+  const { getToken } = useAuthToken();
+  const logger = useLogger("useUser");
+
+  const getAuthHeaders = (): Record<string, string> => {
+    const token = getToken();
+    if (!token) {
+      logger.error("No authentication token found");
+      throw new Error("No authentication token found");
+    }
+    return {
+      Authorization: token,
+      "Content-Type": "application/json",
+    };
+  };
+
+  const executeRequest = async <T>(
+    operationName: string,
+    endpoint: string,
+    options: Parameters<typeof $fetch>[1],
+  ): Promise<{ data: T | undefined; error: IApiErrorResponse | null }> => {
+    try {
+      const headers = getAuthHeaders();
+      const { response, request, error } = useApi<T>(endpoint, {
+        ...options,
+        headers: { ...headers, ...options?.headers },
+      });
+
+      await request();
+
+      if (error.value) {
+        logger.error(`${operationName} failed`, {
+          endpoint,
+          status: error.value.status?.http_code,
+          message: error.value.info,
+        });
+        return { data: undefined, error: error.value };
+      }
+
+      logger.debug(`${operationName} succeeded`, { endpoint });
+      return { data: response.value, error: null };
+    } catch (err: unknown) {
+      const fallbackError: IApiErrorResponse = {
+        status: { id: 0, message: "Error inesperado", http_code: 500 },
+        info:
+          err instanceof Error
+            ? err.message
+            : "Ocurrió un error inesperado antes de realizar la solicitud",
+        data: null,
+      };
+
+      logger.error(`${operationName} threw unexpectedly`, {
+        endpoint,
+        error: fallbackError.info,
+      });
+
+      return { data: undefined, error: fallbackError };
+    }
+  };
+
+  const updateUser = (userId: string, payload: IUserUpdateRequest) =>
+    executeRequest<IUser>("updateUser", "user/edit", {
+      method: "PUT",
+      body: JSON.stringify(payload),
+      query: { id: userId },
+    });
+
+  return { updateUser };
+};

--- a/pages/medicos/perfil/profesional.vue
+++ b/pages/medicos/perfil/profesional.vue
@@ -2,6 +2,7 @@
 import { jwtDecode } from "jwt-decode";
 import { useDocuments } from "~/composables/api/useDocuments";
 import { useSupplier } from "~/composables/api/useSupplier";
+import { useUser } from "~/composables/api/useUser";
 import placeholderAvatar from "@/src/assets/picture.svg";
 
 useSeoMeta({
@@ -24,6 +25,7 @@ const MAX_DETAIL_ATTEMPTS = 3;
 const { show: showToast } = useToast();
 const { updateSupplier, getSupplierById, getAllSuppliers } = useSupplier();
 const { addDocument, getDocumentByCode } = useDocuments();
+const { updateUser } = useUser();
 const { getToken } = useAuthToken();
 const { id: userId } = jwtDecode<DecodedToken>(getToken()!);
 
@@ -38,6 +40,7 @@ const isSubmitting = ref(false);
 const isLoadingProfile = ref(true);
 const isUploadingImage = ref(false);
 const loadError = ref<string | null>(null);
+const pictureModified = ref(false);
 
 const isValidImageUrl = (url: string | null | undefined): boolean =>
   !!url && (url.startsWith("http://") || url.startsWith("https://"));
@@ -146,6 +149,7 @@ const validateImageFile = (file: File): string | null => {
 const removeProfilePicture = () => {
   selectedProfileImage.value = null;
   profileImagePreview.value = null;
+  pictureModified.value = true;
   if (supplierData.value) {
     supplierData.value = { ...supplierData.value, profile_picture_url: "" };
   }
@@ -164,6 +168,7 @@ const handleImageSelection = (event: Event) => {
   }
 
   selectedProfileImage.value = file;
+  pictureModified.value = true;
 
   const reader = new FileReader();
   reader.onload = (e) => {
@@ -179,18 +184,17 @@ const uploadProfileImage = async (): Promise<string | null> => {
   if (!selectedProfileImage.value) return null;
 
   isUploadingImage.value = true;
-  const entityId = supplierId.value ?? userId;
 
   try {
     const { data, error } = await addDocument({
       file: selectedProfileImage.value,
       fields: {
-        title: `profile_picture_${entityId}`,
+        title: `profile_picture_${userId}`,
         type: "IMG",
         description: "Foto de perfil profesional",
-        id_for_table: String(entityId),
-        table: "SUPPLIER",
-        action_type: "GENERAL_GALLERY",
+        id_for_table: userId,
+        table: "users",
+        action_type: "PROFILE_PICTURE",
         user_id: userId,
         is_public: 1,
       },
@@ -214,20 +218,34 @@ const submitProfileUpdate = async () => {
   isSubmitting.value = true;
 
   try {
-    let profilePictureUrl = storedProfileImageUrl.value ?? "";
+    const shouldUpdatePicture = !!selectedProfileImage.value || pictureModified.value;
+    let pictureUrl = storedProfileImageUrl.value ?? "";
 
     if (selectedProfileImage.value) {
       const uploadedUrl = await uploadProfileImage();
       if (!uploadedUrl) return;
-      profilePictureUrl = uploadedUrl;
+      pictureUrl = uploadedUrl;
+    }
+
+    if (shouldUpdatePicture) {
+      const { error: userError } = await updateUser(userId, {
+        profile_picture_url: pictureUrl,
+      });
+      if (userError) {
+        notify(userError.info || "Error al actualizar la foto de perfil", "error");
+        return;
+      }
     }
 
     if (!supplierId.value) {
-      supplierData.value = {
-        ...(supplierData.value ?? ({} as ISupplierDetail)),
-        profile_picture_url: profilePictureUrl,
-      };
-      selectedProfileImage.value = null;
+      if (shouldUpdatePicture) {
+        supplierData.value = {
+          ...(supplierData.value ?? ({} as ISupplierDetail)),
+          profile_picture_url: pictureUrl,
+        };
+        selectedProfileImage.value = null;
+        pictureModified.value = false;
+      }
       notify("Foto de perfil actualizada", "success");
       return;
     }
@@ -235,7 +253,6 @@ const submitProfileUpdate = async () => {
     const payload: ISupplierUpdateRequest = {
       description: profileDescription.value.trim(),
       num_medical_enrollment: medicalEnrollmentNumber.value.trim(),
-      profile_picture_url: profilePictureUrl,
     };
 
     const { data, error } = await updateSupplier(supplierId.value, payload);
@@ -250,10 +267,10 @@ const submitProfileUpdate = async () => {
         ...supplierData.value!,
         description: payload.description,
         num_medical_enrollment: payload.num_medical_enrollment,
-        profile_picture_url: profilePictureUrl,
+        ...(shouldUpdatePicture && { profile_picture_url: pictureUrl }),
       };
-
       selectedProfileImage.value = null;
+      pictureModified.value = false;
       notify("Perfil actualizado exitosamente", "success");
     }
   } catch {


### PR DESCRIPTION
Profile picture uploads were sending profile_picture_url to PUT /supplier/edit, which doesn't handle that field — the backend threw before applying CORS headers, causing the browser to report a CORS error. The correct endpoint is PUT /user/edit (UserController), which owns the profile_picture_url column on the users table.

- Add useUser composable with updateUser hitting PUT /user/edit
- Fix document upload fields: action_type PROFILE_PICTURE, table users, id_for_table userId
- submitProfileUpdate now calls updateUser for picture URL changes and omits profile_picture_url from the supplier payload (description + enrollment only)
- Track picture changes with pictureModified flag to avoid unnecessary user updates