### PR TITLE
Prevent form progression when alternative phone number is toggled but empty

### DIFF
--- a/components/website/reservar-cita-valoracion/formulario-reserva.vue
+++ b/components/website/reservar-cita-valoracion/formulario-reserva.vue
@@ -200,6 +200,7 @@ interface Emits {
   (e: "is-for-external-user", person: "me" | "someoneElse"): void;
   (e: "set-alternative-phone-number", phone: string): void;
   (e: "set-user-description", description: string): void;
+  (e: "toggle-alternative-number", active: boolean): void;
 }
 const props = defineProps<Props>();
 const emit = defineEmits<Emits>();
@@ -264,6 +265,8 @@ const toggleAlternativeNumber = (event: Event): void => {
     alternativeInput.parentElement?.classList.remove("active");
     emit("set-alternative-phone-number", "");
   }
+
+  emit("toggle-alternative-number", isChecked);
 };
 </script>
 

--- a/components/website/reservar-cita-valoracion/index.vue
+++ b/components/website/reservar-cita-valoracion/index.vue
@@ -47,6 +47,7 @@
         @set-alternative-phone-number="setAlternativePhoneNumber"
         @is-for-external-user="setIsForExternalUser"
         @set-user-description="setUserDescription"
+        @toggle-alternative-number="setIsUsingAlternativeNumber"
       />
 
       <WebsiteReservarCitaValoracionConfirmacionReserva
@@ -84,7 +85,7 @@
           @click="nextStep"
           type="button"
           aria-label="Continuar al siguiente paso"
-          :disabled="isLoading"
+          :disabled="isLoading || (internalCurrentStep === 1 && isUsingAlternativeNumber && !alternativePhoneNumber)"
         >
           <span
             v-if="isLoading"
@@ -144,6 +145,7 @@ const isOpenSuccessModal = ref<boolean>(false);
 const isLoading = ref<boolean>(false);
 
 const alternativePhoneNumber = ref<string | null>(null);
+const isUsingAlternativeNumber = ref<boolean>(false);
 const isForExternalUser = ref<"me" | "someoneElse">("me");
 const userDescription = ref<string>("");
 
@@ -194,6 +196,12 @@ const setUserDescription = (description: string) => {
 };
 
 const nextStep = (): void => {
+  if (internalCurrentStep.value === 1) {
+    if (isUsingAlternativeNumber.value && !alternativePhoneNumber.value) {
+      return;
+    }
+  }
+
   if (internalCurrentStep.value === 2) {
     handleConfirmReservation();
     return;
@@ -212,6 +220,13 @@ const prevStep = (): void => {
 
 const setAlternativePhoneNumber = (phone: string): void => {
   alternativePhoneNumber.value = phone;
+};
+
+const setIsUsingAlternativeNumber = (active: boolean): void => {
+  isUsingAlternativeNumber.value = active;
+  if (!active) {
+    alternativePhoneNumber.value = null;
+  }
 };
 
 const handleConfirmReservation = async () => {


### PR DESCRIPTION
Block the "next step" action on step 1 if the user has enabled the alternative number input but left it blank, both via button disabled state and in the nextStep guard. Adds a toggle-alternative-number emit so the parent tracks the checkbox state and can clear the stored number when the toggle is turned off.