### PR TITLE
Auth Protection, Price Fallbacks, and Booking Notification

### DIFF
--- a/components/atoms/icons/correo-icon.vue
+++ b/components/atoms/icons/correo-icon.vue
@@ -1,0 +1,7 @@
+<template>
+  <Icon name="material-symbols:mail-outline" :size="size" />
+</template>
+
+<script lang="ts" setup>
+withDefaults(defineProps<{ size?: string | number }>(), { size: 24 });
+</script>

--- a/components/medicos/modales/pack-preview.vue
+++ b/components/medicos/modales/pack-preview.vue
@@ -238,9 +238,11 @@ const displayDiscountPrice = computed(() => {
   return formatCurrency(rawValue);
 });
 
-const formattedReferencePrice = computed(() =>
-  formatCurrency(props.pack?.reference_price),
-);
+const formattedReferencePrice = computed(() => {
+  const price = props.pack?.reference_price;
+  if (!price || price === 0) return "Precio a definir en cita";
+  return formatCurrency(price);
+});
 
 const formattedValorationPrice = computed(() =>
   formatCurrency(props.pack?.product_valoration_price),

--- a/components/website/formulario-busqueda-medica.vue
+++ b/components/website/formulario-busqueda-medica.vue
@@ -157,6 +157,11 @@ const handleSpecialtyClear = () => {
 };
 
 const searchResults = () => {
+  if (!isAuthenticated.value) {
+    router.push("/auth/login");
+    return;
+  }
+
   const newQuery: Record<string, string> = {
     ...(selectedProcedure.value && {
       procedure_code: selectedProcedure.value.toString(),

--- a/components/website/perfil-doctor/tarjeta-servicio.vue
+++ b/components/website/perfil-doctor/tarjeta-servicio.vue
@@ -65,10 +65,11 @@ const packageName = computed<string>(
 const isKingPackage = computed<boolean>(() => Boolean(props.pkg?.is_king));
 
 const packagePrice = computed<string>(() => {
-  const price = props.pkg?.reference_price;
-  if (!price) return "₡0.00";
+  const raw = props.pkg?.reference_price;
+  const price = Number(raw);
+  if (!price || isNaN(price)) return "Precio a definir en cita";
 
-  return typeof price === "string" ? price : safeCurrencyFormat(price);
+  return safeCurrencyFormat(price);
 });
 
 const originalPrice = computed<string>(() => {

--- a/components/website/reservar-cita-valoracion/reserva-exitosa.vue
+++ b/components/website/reservar-cita-valoracion/reserva-exitosa.vue
@@ -94,6 +94,11 @@
           </tr>
         </tbody>
       </table>
+
+      <div class="successful-reservation__message--email-notice">
+        <AtomsIconsCorreoIcon size="24" />
+        <p>Recibirás un correo de confirmación. Revisa tu spam si no lo encuentras.</p>
+      </div>
     </div>
 
     <template #footer>
@@ -284,6 +289,32 @@ const getSelectedProcedureName = computed(() => {
       line-height: 24px;
       text-align: center;
       color: #353e5c;
+    }
+
+    &--email-notice {
+      display: flex;
+      align-items: flex-start;
+      gap: 8px;
+      margin-top: 12px;
+      padding: 10px 14px;
+      background-color: #fffbeb;
+      border: 1px solid #f5c518;
+      border-radius: 10px;
+      color: #6d758f;
+
+      :deep(.iconify) {
+        flex-shrink: 0;
+        margin-top: 2px;
+        color: #d4a017;
+      }
+
+      p {
+        font-weight: 400;
+        font-size: 14px;
+        line-height: 20px;
+        text-align: left;
+        margin: 0;
+      }
     }
   }
 

--- a/components/website/ultimas-busquedas.vue
+++ b/components/website/ultimas-busquedas.vue
@@ -1,4 +1,7 @@
 <script lang="ts" setup>
+const { authenticated } = useAuthState();
+const router = useRouter();
+
 interface SearchHistory {
   specialtyCode: string;
   specialtyName: string;
@@ -42,6 +45,13 @@ const getSearchLabel = (search: SearchHistory) => {
   return search.procedureName || search.specialtyName;
 };
 
+const handleSearchClick = (event: Event, search: SearchHistory) => {
+  if (!authenticated.value) {
+    event.preventDefault();
+    router.push("/auth/login");
+  }
+};
+
 onMounted(() => {
   loadSearchHistory();
 });
@@ -70,6 +80,7 @@ onMounted(() => {
         :key="`${search.specialtyCode}-${search.procedureCode || 'none'}-${index}`"
         :to="getSearchLink(search)"
         class="latest-search__badge"
+        @click="handleSearchClick($event, search)"
       >
         {{ getSearchLabel(search) }}
       </NuxtLink>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -137,7 +137,7 @@
           </h2>
           <button
             class="call-to-action__button"
-            @click="scrollToBusqueda"
+            @click="handleCtaClick"
             aria-label="Ir al formulario de búsqueda de especialistas"
           >
             <span class="call-to-action__button--text">
@@ -164,6 +164,9 @@ useSeoMeta({
   ogDescription: "Encuentra médicos, agenda citas y gestiona tu salud en un solo lugar.",
 });
 
+const { authenticated } = useAuthState();
+const router = useRouter();
+
 const scrollToBusqueda = () => {
   const element = document.getElementById("home");
   if (element) {
@@ -174,6 +177,14 @@ const scrollToBusqueda = () => {
         searchInput.focus();
       }, 500);
     }
+  }
+};
+
+const handleCtaClick = () => {
+  if (!authenticated.value) {
+    router.push("/auth/login");
+  } else {
+    scrollToBusqueda();
   }
 };
 </script>


### PR DESCRIPTION
This PR introduces three independent improvements:

1. **Authentication guard on search-related actions** – Prevents unauthenticated users from triggering search submissions, clicking recent search badges, or using the homepage CTA. Instead, they are redirected to `/auth/login`.

2. **Price placeholder for zero/missing reference prices** – When a medical package has no `reference_price` or the value is `0`, the UI now displays *“Precio a definir en cita”* instead of `₡0.00` or an empty string. This affects the pack preview modal and the service card on the doctor’s profile.

3. **Email confirmation notice on successful appointment booking** – After a user successfully reserves a valuation appointment, a prominent notice informs them about the confirmation email (including a reminder to check spam). A new reusable `CorreoIcon` component was added for this.

---

### Changes included

#### 1. Auth guard for search flows
- **`formulario-busqueda-medica.vue`** – Added authentication check inside `searchResults()`. Redirects to login if not authenticated.
- **`ultimas-busquedas.vue`** – Added `handleSearchClick` that prevents navigation and redirects to login when user is unauthenticated.
- **`pages/index.vue`** – Modified homepage CTA button: redirects to login if unauthenticated, otherwise scrolls to search form.

#### 2. Price placeholder for zero/missing reference price
- **`pack-preview.vue`** – `formattedReferencePrice` now returns *“Precio a definir en cita”* when `reference_price` is falsy or zero.
- **`tarjeta-servicio.vue`** – `packagePrice` returns the same placeholder if the parsed price is falsy or `NaN`.

#### 3. Email confirmation notice
- **New component:** `components/atoms/icons/correo-icon.vue` – Wrapper for `material-symbols:mail-outline` icon.
- **`reserva-exitosa.vue`** – Added a styled notice block with the mail icon and explanatory text: *“Recibirás un correo de confirmación. Revisa tu spam si no lo encuentras.”*

---

### How to test

#### Auth guard
1. Log out from the application.
2. Try to:
   - Perform a medical search from the homepage.
   - Click on any “Últimas búsquedas” badge.
   - Click the main CTA button on the homepage.
3. Verify you are redirected to `/auth/login` in all cases.
4. Log in and confirm the original actions work as expected (search executes, badge navigates, CTA scrolls).

#### Price placeholder
1. Find a medical package where `reference_price` is `null`, `undefined`, or `0` (or temporarily mock it).
2. Open the pack preview modal → the reference price line should show *“Precio a definir en cita”*.
3. On the doctor’s profile, the corresponding service card should also display the same placeholder instead of `₡0.00`.

#### Email notice
1. Complete a successful valuation appointment reservation.
2. On the success screen, verify that a yellow-bordered notice appears below the reservation details, containing a mail icon and the spam-check reminder text.

---

### 📸 Screenshots (suggested)

| Area | Before | After |
|------|--------|-------|
| Price when missing | `₡0.00` | *Precio a definir en cita* |
| Email notice | Not present | Yellow notice with mail icon |
| Unauthenticated CTA click | Scrolls (or errors) | Redirects to login |

---

### Related commits

- `Redirect unauthenticated users to login on search actions`
- `Show "Precio a definir en cita" when package reference price is zero or missing`
- `Add email confirmation notice to successful reservation screen`

---

### Notes

- The new `CorreoIcon` component accepts a `size` prop (default `24`) and can be reused elsewhere.
- The auth guard uses `useAuthState().authenticated` from the existing auth composable.
- All changes are purely client-side; no backend modifications required.